### PR TITLE
Switch to modern bundler moduleResolution in tsconfig

### DIFF
--- a/src/types/next-logger-route.ts
+++ b/src/types/next-logger-route.ts
@@ -1,3 +1,0 @@
-declare module "@navikt/next-logger/app-dir" {
-  export { POST } from "@navikt/next-logger/dist/routes/app-dir";
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
It is neccessary for importing Aksel alternatives to "dot components". The dot components cannot be used in next server components.

Remove type declaration not neccessary anymore.