### PR TITLE
Use standard response interface in route handlers

### DIFF
--- a/src/app/api/isAlive/route.ts
+++ b/src/app/api/isAlive/route.ts
@@ -1,5 +1,3 @@
-import { NextResponse } from 'next/server'
-
-export function GET(): NextResponse {
-  return NextResponse.json({ message: 'I am alive :)' })
+export function GET() {
+  return Response.json({ message: "I am alive :)" });
 }

--- a/src/app/api/isReady/route.ts
+++ b/src/app/api/isReady/route.ts
@@ -1,14 +1,13 @@
-import { NextResponse } from "next/server";
 import { logger } from "@navikt/next-logger";
 import { getServerEnv } from "@/env-variables/serverEnv";
 
-export async function GET(): Promise<NextResponse> {
+export async function GET() {
   try {
     getServerEnv();
   } catch (e) {
     logger.error(e);
-    return NextResponse.json({ message: "I am not ready :(" }, { status: 500 });
+    return Response.json({ message: "I am not ready :(" }, { status: 500 });
   }
 
-  return NextResponse.json({ message: "I am ready :)" });
+  return Response.json({ message: "I am ready :)" });
 }


### PR DESCRIPTION
Liten ting, men jeg så i eksempelet her at de bruker standard Response interface i stedet for NextResponse (https://developer.mozilla.org/en-US/docs/Web/API/Response). For enkelt hets skyld. Ser ut som man kan bruke NextReqeust og NextResponse hvis man trenger noen av convenience metodene Next tilbyr i tillegg.