### PR TITLE
fix: Include public folder in deployed docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM gcr.io/distroless/nodejs20-debian12@sha256:a6c0e95f6f70fb21586757a846d8b8d2
 
 WORKDIR /app
 
-COPY package.json /app/
 COPY .next/standalone /app/
+COPY public /app/public
 
 EXPOSE 3000
 


### PR DESCRIPTION
Public folder kopieres ikke til standalone mappen av next.

package.json er i standalone mappen fra før.

Vi kan fikse CDN for public-filene senere. Da må Image src-attributt-stiene også endres.