### PR TITLE
Enforce Norwegian time to ensure sync between server and client timezone

### DIFF
--- a/src/components/NyPlanSide/FyllUtPlanSteg/UtkastLagringInfo.tsx
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/UtkastLagringInfo.tsx
@@ -32,6 +32,7 @@ export default function UtkastLagringInfo({
         <span>
           Utkast sist lagret kl.{" "}
           {utkastSistLagretTidspunkt?.toLocaleTimeString("no-NB", {
+            timeZone: "Europe/Oslo",
             hour: "2-digit",
             minute: "2-digit",
             second: "2-digit",

--- a/src/ui-helpers/dateAndTime.ts
+++ b/src/ui-helpers/dateAndTime.ts
@@ -8,6 +8,7 @@ export function getLocaleDateAndTimeString(
   return `${getLocaleDateString(dateTime, dateFormat)} kl. ${dateTime.toLocaleTimeString(
     LOCALE,
     {
+      timeZone: "Europe/Oslo",
       hour: "2-digit",
       minute: "2-digit",
     },
@@ -19,6 +20,7 @@ export function getLocaleDateString(date: Date, format: "long" | "short") {
   const dateIsCurrentYear = date.getFullYear() === currentYear;
 
   const dateOptions: Intl.DateTimeFormatOptions = {
+    timeZone: "Europe/Oslo",
     year:
       DONT_SHOW_YEAR_IF_CURRENT_YEAR && dateIsCurrentYear
         ? undefined


### PR DESCRIPTION
Node bruker UTC for server components, og så har vi også client side tid som blir i lokal tid. 

Testet at å defaulte til norsk tid løser problemet. Men bør diskutere om det er riktig fiks...