### PR TITLE
await getAndLogErrorResultFromNonOkResponse

### DIFF
--- a/src/server/tokenXFetch/tokenXFetchGet.ts
+++ b/src/server/tokenXFetch/tokenXFetchGet.ts
@@ -54,7 +54,7 @@ export async function tokenXFetchGet<S extends z.ZodType>({
   }
 
   if (!response.ok) {
-    const errorResult = getAndLogErrorResultFromNonOkResponse({
+    const errorResult = await getAndLogErrorResultFromNonOkResponse({
       response,
       endpoint,
       method: "GET",


### PR DESCRIPTION
Fikser bare at det henger (f.eks hvis man skriver ugyldig narmesteLederId i url). Må fortsatt håndtere feilen