### PR TITLE
Error handling

### DIFF
--- a/src/common/types/errors.ts
+++ b/src/common/types/errors.ts
@@ -1,0 +1,36 @@
+import { FrontendErrorType } from "@/server/actions/FrontendErrorTypeEnum.ts";
+import { FetchResultError } from "@/server/tokenXFetch/FetchResult.ts";
+
+export enum BackendErrorType {
+  AUTHENTICATION_ERROR = "AUTHENTICATION_ERROR",
+  AUTHORIZATION_ERROR = "AUTHORIZATION_ERROR",
+  NOT_FOUND = "NOT_FOUND",
+  INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR",
+  ILLEGAL_ARGUMENT = "ILLEGAL_ARGUMENT",
+  BAD_REQUEST = "BAD_REQUEST",
+  LEGE_NOT_FOUND = "LEGE_NOT_FOUND",
+  PLAN_NOT_FOUND = "PLAN_NOT_FOUND",
+  SYKMELDT_NOT_FOUND = "SYKMELDT_NOT_FOUND",
+  CONFLICT = "CONFLICT",
+}
+
+export type StandardActionErrorType =
+  | BackendErrorType.AUTHENTICATION_ERROR
+  | BackendErrorType.AUTHORIZATION_ERROR
+  | BackendErrorType.NOT_FOUND
+  | BackendErrorType.INTERNAL_SERVER_ERROR
+  | BackendErrorType.BAD_REQUEST
+  | FrontendErrorType;
+
+export type DelPlanMedLegeErrorType =
+  | StandardActionErrorType
+  | BackendErrorType.LEGE_NOT_FOUND
+  | BackendErrorType.PLAN_NOT_FOUND
+  | BackendErrorType.CONFLICT;
+
+export type DelPlanMedVeilederErrorType =
+  | StandardActionErrorType
+  | BackendErrorType.PLAN_NOT_FOUND
+  | BackendErrorType.CONFLICT;
+
+export type ActionError<E extends string = string> = FetchResultError<E>;

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/DelPlanMedLegeButtonAndStatus.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/DelPlanMedLegeButtonAndStatus.tsx
@@ -41,15 +41,7 @@ export function DelPlanMedLegeButtonAndStatus({ planId }: Props) {
         )}
       </HStack>
 
-      {errorDelMedLege && (
-        // TODO: Show this error message for specific error codes only
-        <Alert variant="error">
-          Du får dessverre ikke delt denne planen med legen herfra. Det kan
-          hende at den ansatte ikke har en fastlege, eller at fastlegen ikke kan
-          ta imot elektroniske meldinger. I dette tilfellet må dere laste ned og
-          skrive ut planen slik at dere får delt den med legen manuelt.
-        </Alert>
-      )}
+      {errorDelMedLege && <Alert variant="error">{errorDelMedLege}</Alert>}
     </VStack>
   );
 }

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/DelPlanMedVeilederButtonAndStatus.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/DelPlanMedVeilederButtonAndStatus.tsx
@@ -38,7 +38,12 @@ export function DelPlanMedVeilederButtonAndStatus({ planId }: Props) {
           {getLocaleDateAndTimeString(deltMedVeilederTidspunkt, "long")}.
         </Alert>
       ) : (
-        errorDelMedVeileder && <>{/* TODO: Show some error message */}</>
+        errorDelMedVeileder && (
+          <Alert variant="error">
+            Det oppstod en feil ved deling av planen med Nav-veileder. Vennligst
+            prøv igjen senere.
+          </Alert>
+        )
       )}
     </HStack>
   );

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/useDelPlanMedVeilederAction.ts
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/useDelPlanMedVeilederAction.ts
@@ -1,35 +1,55 @@
 import { useActionState } from "react";
 import { useParams } from "next/navigation";
+import { DelPlanMedVeilederErrorType } from "@/common/types/errors";
 import {
-  DelPlanMedVeilederActionState,
+  DelMedVeilederResponse,
   delPlanMedVeilederServerAction,
 } from "@/server/actions/delPlanMedVeileder";
+import { FetchUpdateResultWithResponse } from "@/server/tokenXFetch/FetchResult";
+import { getGeneralActionErrorMessage } from "@/utils/error-messages";
 
 export function useDelPlanMedVeilederAction(
   initialDeltMedVeilederTidspunkt: Date | null,
 ) {
   const { narmesteLederId } = useParams<{ narmesteLederId: string }>();
 
-  const initialDelPlanMedVeilederActionState: DelPlanMedVeilederActionState = {
-    deltMedVeilederTidspunkt: initialDeltMedVeilederTidspunkt,
-    errorDelMedVeileder: null,
+  const initialState: FetchUpdateResultWithResponse<
+    DelMedVeilederResponse | undefined,
+    DelPlanMedVeilederErrorType
+  > = {
+    success: true,
+    data: undefined,
   };
 
-  const [
-    { deltMedVeilederTidspunkt, errorDelMedVeileder },
-    delMedVeilederAction,
-    isPendingDelMedVeileder,
-  ] = useActionState(
-    innerDelMedVeilederAction,
-    initialDelPlanMedVeilederActionState,
-  );
+  const [result, delMedVeilederAction, isPendingDelMedVeileder] =
+    useActionState(innerDelMedVeilederAction, initialState);
 
-  function innerDelMedVeilederAction(
-    _previousState: DelPlanMedVeilederActionState,
+  async function innerDelMedVeilederAction(
+    _previousState: FetchUpdateResultWithResponse<
+      DelMedVeilederResponse | undefined,
+      DelPlanMedVeilederErrorType
+    >,
     { planId }: { planId: string },
-  ): Promise<DelPlanMedVeilederActionState> {
-    return delPlanMedVeilederServerAction(narmesteLederId, planId);
+  ): Promise<
+    FetchUpdateResultWithResponse<
+      DelMedVeilederResponse | undefined,
+      DelPlanMedVeilederErrorType
+    >
+  > {
+    return await delPlanMedVeilederServerAction(narmesteLederId, planId);
   }
+
+  const errorDelMedVeileder = !result.success
+    ? getGeneralActionErrorMessage(
+        result.error,
+        "Vi klarte ikke å dele planen med NAV. Vennligst prøv igjen senere.",
+      )
+    : null;
+
+  const deltMedVeilederTidspunkt =
+    result.success && result.data
+      ? new Date(result.data.deltMedVeilederTidspunkt)
+      : initialDeltMedVeilederTidspunkt;
 
   return {
     deltMedVeilederTidspunkt,

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/OverskrivUtkastModal/OverskrivUtkastMedInnholdFraAktivPlanModal.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/OverskrivUtkastModal/OverskrivUtkastMedInnholdFraAktivPlanModal.tsx
@@ -36,7 +36,7 @@ export function OverskrivUtkastModal({ ref }: Props) {
           <Alert variant="error">
             {getGeneralActionErrorMessage(
               result.error,
-              "Beklager, noe gikk galt.",
+              "Beklager, noe gikk galt når vi prøvde å erstatte utkastet. Vennligst prøv igjen senere.",
             )}
           </Alert>
         )}

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/OverskrivUtkastModal/OverskrivUtkastMedInnholdFraAktivPlanModal.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/OverskrivUtkastModal/OverskrivUtkastMedInnholdFraAktivPlanModal.tsx
@@ -2,6 +2,7 @@ import { useActionState } from "react";
 import { useParams } from "next/navigation";
 import { Alert, BodyLong, Button, Modal } from "@navikt/ds-react";
 import { overskrivUtkastMedInnholdFraAktivPlanServerAction } from "@/server/actions/overskrivUtkastMedInnholdFraAktivPlan";
+import { getGeneralActionErrorMessage } from "@/utils/error-messages";
 
 interface Props {
   ref: React.RefObject<HTMLDialogElement | null>;
@@ -10,9 +11,10 @@ interface Props {
 export function OverskrivUtkastModal({ ref }: Props) {
   const { narmesteLederId } = useParams<{ narmesteLederId: string }>();
 
-  const [{ error }, overskrivUtkastAction, isPendingOverskrivUtkast] =
+  const [result, overskrivUtkastAction, isPendingOverskrivUtkast] =
     useActionState(overskrivUtkastMedInnholdFraAktivPlanServerAction, {
-      error: null,
+      success: true,
+      data: undefined,
     });
 
   return (
@@ -30,8 +32,14 @@ export function OverskrivUtkastModal({ ref }: Props) {
           erstattet med innholdet i denne planen. Vil du fortsette?
         </BodyLong>
 
-        {/* TODO: Improve error message */}
-        {error && <Alert variant="error">Beklager, noe gikk galt.</Alert>}
+        {!result.success && (
+          <Alert variant="error">
+            {getGeneralActionErrorMessage(
+              result.error,
+              "Beklager, noe gikk galt.",
+            )}
+          </Alert>
+        )}
       </Modal.Body>
 
       <Modal.Footer>

--- a/src/components/NyPlanSide/FyllUtPlanSteg/FyllUtPlanSteg.tsx
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/FyllUtPlanSteg.tsx
@@ -1,3 +1,6 @@
+import { Alert } from "@navikt/ds-react";
+import { FetchResultError } from "@/server/tokenXFetch/FetchResult";
+import { getGeneralActionErrorMessage } from "@/utils/error-messages";
 import FyllUtPlanButtonsAndSavingInfo from "./FyllUtPlanButtonsAndSavingInfo";
 import UtkastLagringInfo from "./UtkastLagringInfo";
 import FormErrorSummary from "./form/OPFormErrorSummary";
@@ -13,6 +16,7 @@ interface Props {
   errorSummaryRef: React.RefObject<HTMLDivElement | null>;
   onAvsluttOgFortsettSenereClick: () => void;
   onGoToOppsummeringClick: () => void;
+  error: FetchResultError | null;
 }
 
 const FyllUtPlanSteg = withForm({
@@ -27,6 +31,7 @@ const FyllUtPlanSteg = withForm({
     errorSummaryRef,
     onAvsluttOgFortsettSenereClick,
     onGoToOppsummeringClick,
+    error,
   }) => {
     return (
       <section>
@@ -49,6 +54,16 @@ const FyllUtPlanSteg = withForm({
             />
           }
         />
+        {error && (
+          <div className="mt-8">
+            <Alert variant="error">
+              {getGeneralActionErrorMessage(
+                error,
+                "Vi klarte ikke å lagre utkastet ditt. Vennligst prøv igjen senere.",
+              )}
+            </Alert>
+          </div>
+        )}
       </section>
     );
   },

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useFerdigstillOppfolgingsplanAction.tsx
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useFerdigstillOppfolgingsplanAction.tsx
@@ -12,9 +12,12 @@ export type FerdigstillPlanActionPayload = z.infer<
 export default function useFerdigstillOppfolgingsplanAction() {
   const { narmesteLederId } = useParams<{ narmesteLederId: string }>();
 
-  const initialFerdigstillState = { error: null };
+  const initialFerdigstillState: FetchUpdateResult = {
+    success: true,
+    data: undefined,
+  };
 
-  const [{ error }, ferdigstillPlanAction, isPendingFerdigstillPlan] =
+  const [result, ferdigstillPlanAction, isPendingFerdigstillPlan] =
     useActionState(innerFerdigstillPlanAction, initialFerdigstillState);
 
   function innerFerdigstillPlanAction(
@@ -33,6 +36,6 @@ export default function useFerdigstillOppfolgingsplanAction() {
   return {
     startFerdigstillPlanAction,
     isPendingFerdigstillPlan,
-    error,
+    error: !result.success ? result.error : null,
   };
 }

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useOppfolgingsplanForm.ts
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useOppfolgingsplanForm.ts
@@ -83,14 +83,21 @@ export default function useOppfolgingsplanForm({
     },
   });
 
-  const { isSavingUtkast, sistLagretTidspunkt, startLagreUtkastIfChanges } =
-    useOppfolgingsplanUtkastLagring({
-      initialFormValues,
-      initialSistLagretTidspunkt,
-    });
+  const {
+    isSavingUtkast,
+    sistLagretTidspunkt,
+    startLagreUtkastIfChanges,
+    error: saveUtkastError,
+  } = useOppfolgingsplanUtkastLagring({
+    initialFormValues,
+    initialSistLagretTidspunkt,
+  });
 
-  const { startFerdigstillPlanAction, isPendingFerdigstillPlan } =
-    useFerdigstillOppfolgingsplanAction();
+  const {
+    startFerdigstillPlanAction,
+    isPendingFerdigstillPlan,
+    error: ferdigstillPlanError,
+  } = useFerdigstillOppfolgingsplanAction();
 
   function saveIfChangesAndProceedToOppsummering(
     values: OppfolgingsplanFormUnderArbeid,
@@ -141,5 +148,7 @@ export default function useOppfolgingsplanForm({
     isPendingFerdigstillPlan,
     saveIfChangesAndExit,
     goBackToFyllUtPlanSteg,
+    saveUtkastError,
+    ferdigstillPlanError,
   };
 }

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useOppfolgingsplanUtkastLagring.ts
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useOppfolgingsplanUtkastLagring.ts
@@ -75,7 +75,7 @@ export default function useOppfolgingsplanUtkastLagring({
     if (hasValuesChangedFromPreviousSave) {
       const result = await lagreUtkastServerAction(narmesteLederId, values);
 
-      if (result.error) {
+      if (!result.success) {
         newActionState = {
           sistLagretUtkast: previousState.sistLagretUtkast,
           sistLagretTidspunkt: previousState.sistLagretTidspunkt,

--- a/src/components/NyPlanSide/LagPlanVeiviser.tsx
+++ b/src/components/NyPlanSide/LagPlanVeiviser.tsx
@@ -32,6 +32,8 @@ export default function LagPlanVeiviser({ lagretUtkastPromise }: Props) {
     isPendingFerdigstillPlan,
     saveIfChangesAndExit,
     goBackToFyllUtPlanSteg,
+    saveUtkastError,
+    ferdigstillPlanError,
   } = useOppfolgingsplanForm({
     initialLagretUtkast,
     initialSistLagretTidspunkt,
@@ -53,6 +55,7 @@ export default function LagPlanVeiviser({ lagretUtkastPromise }: Props) {
           onGoToOppsummeringClick={() =>
             form.handleSubmit({ submitAction: "fortsettTilOppsummering" })
           }
+          error={saveUtkastError}
         />
       </Activity>
 
@@ -66,6 +69,7 @@ export default function LagPlanVeiviser({ lagretUtkastPromise }: Props) {
           onFerdigstillPlanClick={() =>
             form.handleSubmit({ submitAction: "ferdigstill" })
           }
+          error={ferdigstillPlanError}
         />
       </Activity>
     </section>

--- a/src/components/NyPlanSide/OppsummeringSteg/OppsummeringSteg.tsx
+++ b/src/components/NyPlanSide/OppsummeringSteg/OppsummeringSteg.tsx
@@ -1,6 +1,8 @@
 import z from "zod";
-import { BodyLong, Heading } from "@navikt/ds-react";
+import { Alert, BodyLong, Heading } from "@navikt/ds-react";
 import { OppfolgingsplanFormFerdigstillSchema } from "@/schema/oppfolgingsplanFormSchemas";
+import { FetchResultError } from "@/server/tokenXFetch/FetchResult";
+import { getGeneralActionErrorMessage } from "@/utils/error-messages";
 import { oppfolgingsplanFormDefaultValues } from "../FyllUtPlanSteg/form/form-options";
 import { withForm } from "../FyllUtPlanSteg/form/hooks/form";
 import NarDuFerdigstillerPlanenAlert from "./NarDuFerdigstillerPlanenAlert";
@@ -11,6 +13,7 @@ interface Props {
   isPendingFerdigstillPlan: boolean;
   onGoBack: () => void;
   onFerdigstillPlanClick: () => void;
+  error: FetchResultError | null;
 }
 
 const OppsummeringSteg = withForm({
@@ -21,6 +24,7 @@ const OppsummeringSteg = withForm({
     isPendingFerdigstillPlan,
     onGoBack,
     onFerdigstillPlanClick,
+    error,
   }) => {
     return (
       <section>
@@ -54,6 +58,17 @@ const OppsummeringSteg = withForm({
           onFerdigstillPlanClick={onFerdigstillPlanClick}
           onGoBackClick={onGoBack}
         />
+
+        {error && (
+          <div className="mt-8">
+            <Alert variant="error">
+              {getGeneralActionErrorMessage(
+                error,
+                "Vi klarte ikke å ferdigstille planen. Vennligst prøv igjen senere.",
+              )}
+            </Alert>
+          </div>
+        )}
       </section>
     );
   },

--- a/src/components/OversiktSide/PlanListe/SlettUtkast/SlettUtkastModal.tsx
+++ b/src/components/OversiktSide/PlanListe/SlettUtkast/SlettUtkastModal.tsx
@@ -23,11 +23,11 @@ export function SlettUtkastModal({ modalRef }: Props) {
         <BodyLong>Er du sikker på at du vil slette utkastet ditt?</BodyLong>
 
         {error && (
-          <div className="mb-4">
+          <div className="mt-4">
             <Alert variant="error">
               {getGeneralActionErrorMessage(
                 error,
-                "Vi klarte ikke å slette utkastet. Vennligst prøv igjen senere.",
+                "Noe gikk galt når vi prøvde å slette utkastet. Vennligst prøv igjen senere.",
               )}
             </Alert>
           </div>

--- a/src/components/OversiktSide/PlanListe/SlettUtkast/SlettUtkastModal.tsx
+++ b/src/components/OversiktSide/PlanListe/SlettUtkast/SlettUtkastModal.tsx
@@ -1,4 +1,5 @@
-import { BodyLong, Button, Modal } from "@navikt/ds-react";
+import { Alert, BodyLong, Button, Modal } from "@navikt/ds-react";
+import { getGeneralActionErrorMessage } from "@/utils/error-messages";
 import useSlettUtkastAction from "./useSlettUtkastAction";
 
 interface Props {
@@ -21,7 +22,16 @@ export function SlettUtkastModal({ modalRef }: Props) {
       <Modal.Body>
         <BodyLong>Er du sikker på at du vil slette utkastet ditt?</BodyLong>
 
-        {error && <>{/* TODO: Vise feilmelding */}</>}
+        {error && (
+          <div className="mb-4">
+            <Alert variant="error">
+              {getGeneralActionErrorMessage(
+                error,
+                "Vi klarte ikke å slette utkastet. Vennligst prøv igjen senere.",
+              )}
+            </Alert>
+          </div>
+        )}
       </Modal.Body>
 
       <Modal.Footer>

--- a/src/components/OversiktSide/PlanListe/SlettUtkast/useSlettUtkastAction.tsx
+++ b/src/components/OversiktSide/PlanListe/SlettUtkast/useSlettUtkastAction.tsx
@@ -10,9 +10,12 @@ type ActionPayload = {
 export default function useSlettUtkastAction() {
   const { narmesteLederId } = useParams<{ narmesteLederId: string }>();
 
-  const initialSlettUtkastState: FetchUpdateResult = { error: null };
+  const initialSlettUtkastState: FetchUpdateResult = {
+    success: true,
+    data: undefined,
+  };
 
-  const [{ error }, slettUtkastAction, isPendingSlettUtkast] = useActionState(
+  const [result, slettUtkastAction, isPendingSlettUtkast] = useActionState(
     innerSlettUtkastAction,
     initialSlettUtkastState,
   );
@@ -23,7 +26,7 @@ export default function useSlettUtkastAction() {
   ): Promise<FetchUpdateResult> {
     const actionState = await slettUtkastServerAction(narmesteLederId);
 
-    if (actionState.error === null) {
+    if (actionState.success) {
       onSuccess();
     }
 
@@ -33,6 +36,6 @@ export default function useSlettUtkastAction() {
   return {
     slettUtkastAction,
     isPendingSlettUtkast,
-    error,
+    error: !result.success ? result.error : null,
   };
 }

--- a/src/server/actions/delPlanMedLege.ts
+++ b/src/server/actions/delPlanMedLege.ts
@@ -24,14 +24,21 @@ export async function delPlanMedLegeServerAction(
     };
   }
 
-  await tokenXFetchUpdate({
+  const fetchResult = await tokenXFetchUpdate({
     targetApi: TokenXTargetApi.SYFO_OPPFOLGINGSPLAN_BACKEND,
     endpoint: getEndpointDelMedLegeForAG(narmesteLederId, planId),
   });
 
-  // satisfy typescript for now
-  return {
-    deltMedLegeTidspunkt: new Date(),
-    errorDelMedLege: null,
-  };
+  if (fetchResult.error) {
+    return {
+      deltMedLegeTidspunkt: null,
+      errorDelMedLege:
+        fetchResult.error.message || "Ukjent feil ved deling med lege",
+    };
+  } else {
+    return {
+      deltMedLegeTidspunkt: new Date(),
+      errorDelMedLege: null,
+    };
+  }
 }

--- a/src/server/actions/delPlanMedLege.ts
+++ b/src/server/actions/delPlanMedLege.ts
@@ -1,44 +1,53 @@
 "use server";
 
 import { getEndpointDelMedLegeForAG } from "@/common/backend-endpoints";
+import { DelPlanMedLegeErrorType } from "@/common/types/errors";
 import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import { TokenXTargetApi } from "../auth/tokenXExchange";
 import { simulateBackendDelay } from "../fetchData/mockData/simulateBackendDelay";
+import { FetchUpdateResultWithResponse } from "../tokenXFetch/FetchResult";
 import { tokenXFetchUpdate } from "../tokenXFetch/tokenXFetchUpdate";
 
-export interface DelPlanMedLegeActionState {
-  deltMedLegeTidspunkt: Date | null;
-  errorDelMedLege: string | null;
+export interface DelMedLegeResponse {
+  deltMedLegeTidspunkt: string;
 }
 
 export async function delPlanMedLegeServerAction(
   narmesteLederId: string,
   planId: string,
-): Promise<DelPlanMedLegeActionState> {
+): Promise<
+  FetchUpdateResultWithResponse<DelMedLegeResponse, DelPlanMedLegeErrorType>
+> {
   if (isLocalOrDemo) {
     await simulateBackendDelay();
 
     return {
-      deltMedLegeTidspunkt: new Date(),
-      errorDelMedLege: null,
+      success: true,
+      data: {
+        deltMedLegeTidspunkt: new Date().toISOString(),
+      },
     };
   }
 
-  const fetchResult = await tokenXFetchUpdate({
+  const result = (await tokenXFetchUpdate({
     targetApi: TokenXTargetApi.SYFO_OPPFOLGINGSPLAN_BACKEND,
     endpoint: getEndpointDelMedLegeForAG(narmesteLederId, planId),
-  });
+  })) as FetchUpdateResultWithResponse<
+    DelMedLegeResponse,
+    DelPlanMedLegeErrorType
+  >;
 
-  if (fetchResult.error) {
+  if (!result.success) {
     return {
-      deltMedLegeTidspunkt: null,
-      errorDelMedLege:
-        fetchResult.error.message || "Ukjent feil ved deling med lege",
-    };
-  } else {
-    return {
-      deltMedLegeTidspunkt: new Date(),
-      errorDelMedLege: null,
+      success: false,
+      error: result.error,
     };
   }
+
+  return {
+    success: true,
+    data: {
+      deltMedLegeTidspunkt: new Date().toISOString(),
+    },
+  };
 }

--- a/src/server/actions/overskrivUtkastMedInnholdFraAktivPlan.ts
+++ b/src/server/actions/overskrivUtkastMedInnholdFraAktivPlan.ts
@@ -35,6 +35,7 @@ export async function overskrivUtkastMedInnholdFraAktivPlanServerAction(
     );
 
     return {
+      success: false,
       error: {
         type: FrontendErrorType.SERVER_ACTION_INPUT_VALIDATION_ERROR,
       },
@@ -47,6 +48,7 @@ export async function overskrivUtkastMedInnholdFraAktivPlanServerAction(
     aktivPlanResponse = await fetchAktivPlanForAG(narmesteLederId);
   } catch (err) {
     return {
+      success: false,
       error: err as FetchResultError,
     };
   }
@@ -65,8 +67,11 @@ export async function overskrivUtkastMedInnholdFraAktivPlanServerAction(
     convertedPlanContent,
   );
 
-  if (lagreUtkastResult.error) {
-    return lagreUtkastResult;
+  if (!lagreUtkastResult.success) {
+    return {
+      success: false,
+      error: lagreUtkastResult.error,
+    };
   } else {
     // Redirect to ny plan page on success
     return redirect(getAGOpprettNyPlanHref(narmesteLederId));

--- a/src/server/actions/slettUtkast.ts
+++ b/src/server/actions/slettUtkast.ts
@@ -2,6 +2,7 @@
 
 import { refresh } from "next/cache";
 import { getEndpointUtkastForAG } from "@/common/backend-endpoints";
+import { StandardActionErrorType } from "@/common/types/errors.ts";
 import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import { TokenXTargetApi } from "../auth/tokenXExchange";
 import { simulateBackendDelay } from "../fetchData/mockData/simulateBackendDelay";
@@ -10,12 +11,12 @@ import { tokenXFetchUpdate } from "../tokenXFetch/tokenXFetchUpdate";
 
 export async function slettUtkastServerAction(
   narmesteLederId: string,
-): Promise<FetchUpdateResult> {
+): Promise<FetchUpdateResult<StandardActionErrorType>> {
   if (isLocalOrDemo) {
     await simulateBackendDelay();
 
     refresh();
-    return { error: null };
+    return { success: true, data: undefined };
   }
 
   const result = await tokenXFetchUpdate({
@@ -24,10 +25,10 @@ export async function slettUtkastServerAction(
     endpoint: getEndpointUtkastForAG(narmesteLederId),
   });
 
-  if (result.error) {
-    return result;
+  if (!result.success) {
+    return result as FetchUpdateResult<StandardActionErrorType>;
   } else {
     refresh();
-    return { error: null };
+    return { success: true, data: undefined };
   }
 }

--- a/src/server/actions/submitFlexjarFeedback.ts
+++ b/src/server/actions/submitFlexjarFeedback.ts
@@ -27,7 +27,7 @@ export async function submitFlexjarFeedback(
     responseDataSchema: flexjarResponseSchema,
   });
 
-  if (result.error) {
+  if (!result.success) {
     throw new Error("Failed to submit feedback");
   }
 

--- a/src/server/tokenXFetch/FetchResult.ts
+++ b/src/server/tokenXFetch/FetchResult.ts
@@ -11,18 +11,17 @@ export const fetchResultErrorSchema = z.object({
   message: z.string().optional(),
 });
 
-export type FetchResultError = z.infer<typeof fetchResultErrorSchema>;
-
-export type FetchUpdateResult = {
-  error: FetchResultError | null;
+export type FetchResultError<E extends string = string> = {
+  type: E;
+  message?: string;
 };
 
-export type FetchUpdateResultWithResponse<T> =
-  | {
-      error: null;
-      data: T;
-    }
-  | {
-      error: FetchResultError;
-      data: null;
-    };
+export type Result<T, E extends string = string> =
+  | { success: true; data: T }
+  | { success: false; error: FetchResultError<E> };
+
+export type FetchUpdateResult<E extends string = string> = Result<void, E>;
+export type FetchUpdateResultWithResponse<
+  T,
+  E extends string = string,
+> = Result<T, E>;

--- a/src/server/tokenXFetch/tokenXFetchUpdate.ts
+++ b/src/server/tokenXFetch/tokenXFetchUpdate.ts
@@ -43,6 +43,7 @@ export async function tokenXFetchUpdate({
     );
   } catch (error) {
     return {
+      success: false,
       error: error as FetchResultError,
     };
   }
@@ -57,7 +58,7 @@ export async function tokenXFetchUpdate({
   } catch (error) {
     const errorResult = getAndLogFetchNetworkError({ error, endpoint, method });
 
-    return { error: errorResult };
+    return { success: false, error: errorResult };
   }
 
   if (!response.ok) {
@@ -67,10 +68,10 @@ export async function tokenXFetchUpdate({
       method,
     });
 
-    return { error: errorResult };
+    return { success: false, error: errorResult };
   } else {
     // Ok response
-    return { error: null };
+    return { success: true, data: undefined };
   }
 }
 
@@ -103,8 +104,8 @@ export async function tokenXFetchUpdateWithResponse<S extends z.ZodType>({
     );
   } catch (error) {
     return {
+      success: false,
       error: error as FetchResultError,
-      data: null,
     };
   }
 
@@ -118,7 +119,7 @@ export async function tokenXFetchUpdateWithResponse<S extends z.ZodType>({
   } catch (error) {
     const errorResult = getAndLogFetchNetworkError({ error, endpoint, method });
 
-    return { error: errorResult, data: null };
+    return { success: false, error: errorResult };
   }
 
   if (!response.ok) {
@@ -128,7 +129,7 @@ export async function tokenXFetchUpdateWithResponse<S extends z.ZodType>({
       method,
     });
 
-    return { error: errorResult, data: null };
+    return { success: false, error: errorResult };
   } else {
     // Valididate response data
     const { success, validatedData } = await validateResponseBody({
@@ -139,13 +140,13 @@ export async function tokenXFetchUpdateWithResponse<S extends z.ZodType>({
     });
 
     if (success) {
-      return { error: null, data: validatedData };
+      return { success: true, data: validatedData };
     } else {
       return {
+        success: false,
         error: {
           type: FrontendErrorType.OK_RESPONSE_BUT_RESPONSE_BODY_INVALID,
         },
-        data: null,
       };
     }
   }

--- a/src/utils/error-messages.ts
+++ b/src/utils/error-messages.ts
@@ -1,0 +1,54 @@
+import { logger } from "@navikt/next-logger";
+import { FrontendErrorType } from "@/server/actions/FrontendErrorTypeEnum";
+import { FetchResultError } from "@/server/tokenXFetch/FetchResult";
+import {
+  ActionError,
+  BackendErrorType,
+  DelPlanMedLegeErrorType,
+} from "../common/types/errors";
+
+const ERROR_DEL_PLAN_MED_LEGE =
+  `Du får dessverre ikke delt denne planen med legen herfra. Det kan hende at den ansatte ikke har en fastlege, ` +
+  `eller at fastlegen ikke kan ta imot elektroniske meldinger. I dette tilfellet må dere laste ned og skrive ut ` +
+  `planen slik at dere får delt den med legen manuelt.`;
+
+function isUnknownErrorType(type: string): boolean {
+  const isBackendError = Object.values(BackendErrorType).includes(
+    type as BackendErrorType,
+  );
+  const isFrontendError = Object.values(FrontendErrorType).includes(
+    type as FrontendErrorType,
+  );
+  return !isBackendError && !isFrontendError;
+}
+
+export function getGeneralActionErrorMessage(
+  error: ActionError,
+  fallbackMessage: string,
+): string {
+  if (error.type === BackendErrorType.AUTHENTICATION_ERROR) {
+    return "Du har blitt logget ut. Vennligst logg inn igjen.";
+  }
+  if (error.type === BackendErrorType.AUTHORIZATION_ERROR) {
+    return "Du har ikke tilgang til å utføre denne handlingen.";
+  }
+
+  if (isUnknownErrorType(error.type)) {
+    logger.warn(`Unhandled error type: ${error.type}`);
+  }
+
+  return fallbackMessage;
+}
+
+export function getDelPlanMedLegeErrorMessage(
+  error: FetchResultError<DelPlanMedLegeErrorType>,
+): string {
+  if (error.type === BackendErrorType.LEGE_NOT_FOUND) {
+    return ERROR_DEL_PLAN_MED_LEGE;
+  }
+
+  return getGeneralActionErrorMessage(
+    error,
+    "Vi har problem med å dele planen med fastlegen akkurat nå. Vennligst prøv igjen senere.",
+  );
+}


### PR DESCRIPTION
Refaktorerte litt for å få til dette, og endret til å bruke feilhåndtering litt ala Tanstack query
```
export type Result<T, E extends string = string> =
  | { success: true; data: T }
  | { success: false; error: FetchResultError<E> };
```

Har typet opp feiltypene vi kan få fra backend, og logger også ukjente feil som vi ikke typer enda.