### PR TITLE
Remove next config option that is now on by default

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -68,7 +68,6 @@ const nextConfig: NextConfig = {
   ],
   experimental: {
     optimizePackageImports: ["@navikt/ds-react", "@navikt/aksel-icons"],
-    turbopackFileSystemCacheForDev: true,
   },
 };
 


### PR DESCRIPTION
https://nextjs.org/blog/next-16-1#turbopack-file-system-caching-for-next-dev