### PR TITLE
Refactor analytics code

### DIFF
--- a/src/common/analytics/events-and-properties/knappKlikket-properties.ts
+++ b/src/common/analytics/events-and-properties/knappKlikket-properties.ts
@@ -1,0 +1,106 @@
+/** Event properties for "knapp klikket" analytics events */
+export const knappKlikket = {
+  oversiktSide: {
+    lagNyOppfolgingsplan: {
+      komponentId: "lag-ny-oppfolgingsplan-knapp",
+      tekst: "Lag en ny oppfølgingsplan",
+      kontekst: "OversiktSide",
+    },
+    slettUtkastModalTrigger: {
+      komponentId: "slett-utkast-modal-trigger-knapp",
+      tekst: "Slett utkast",
+      kontekst: "OversiktSide",
+    },
+    slettUtkastModal: {
+      bekreft: {
+        komponentId: "slett-utkast-modal-bekreft-knapp",
+        tekst: "Slett utkast",
+        kontekst: "OversiktSide-SlettUtkastModal",
+      },
+      avbryt: {
+        komponentId: "slett-utkast-modal-avbryt-knapp",
+        tekst: "Avbryt",
+        kontekst: "OversiktSide-SlettUtkastModal",
+      },
+    },
+  },
+  nyPlanSide: {
+    fyllUtSteg: {
+      avsluttOgFortsettSenere: {
+        komponentId: "avslutt-og-fortsett-senere-knapp",
+        tekst: "Avslutt og fortsett senere",
+        kontekst: "NyPlanSide-FyllUtPlanSteg",
+      },
+    },
+    oppsummeringSteg: {
+      gaTilbake: {
+        komponentId: "ga-tilbake-fra-oppsummering-knapp",
+        tekst: "Gå tilbake",
+        kontekst: "NyPlanSide-OppsummeringSteg",
+      },
+      avsluttOgFortsettSenere: {
+        komponentId: "avslutt-og-fortsett-senere-knapp",
+        tekst: "Avslutt og fortsett senere",
+        kontekst: "NyPlanSide-OppsummeringSteg",
+      },
+    },
+  },
+  ferdigstiltPlanSide: {
+    visPdf: {
+      komponentId: "vis-pdf-knapp",
+      tekst: "Vis PDF",
+      kontekst: "FerdigstiltPlanSide",
+    },
+    tilbakeTilOversikt: {
+      komponentId: "tilbake-til-oversikt-knapp",
+      tekst: "Tilbake til oppfølgingsplaner",
+      kontekst: "FerdigstiltPlanSide",
+    },
+  },
+  aktivPlanSide: {
+    endreOppfolgingsplan: {
+      komponentId: "endre-oppfolgingsplan-knapp",
+      tekst: "Endre oppfølgingsplanen",
+      kontekst: "AktivPlanSide",
+    },
+    lagNyOppfolgingsplan: {
+      komponentId: "lag-ny-oppfolgingsplan-knapp",
+      tekst: "Lag en ny plan",
+      kontekst: "AktivPlanSide",
+    },
+    delMedFastlege: {
+      komponentId: "del-med-fastlege-knapp",
+      tekst: "Send til fastlege",
+      kontekst: "AktivPlanSide",
+    },
+    delMedVeileder: {
+      komponentId: "del-med-nav-knapp",
+      tekst: "Send til Nav-veileder",
+      kontekst: "AktivPlanSide",
+    },
+    overskriveUtkastForAEndreModal: {
+      bekreft: {
+        komponentId: "erstatt-utkast-og-fortsett-knapp",
+        tekst: "Erstatt utkast og fortsett",
+        kontekst: "AktivPlanSide-OverskriveUtkastForAEndreModal",
+      },
+      avbryt: {
+        komponentId: "avbryt-erstatt-utkast-knapp",
+        tekst: "Avbryt",
+        kontekst: "AktivPlanSide-OverskriveUtkastForAEndreModal",
+      },
+    },
+    sletteUtkastForALageNyModal: {
+      bekreft: {
+        komponentId: "slett-utkast-og-fortsett-knapp",
+        tekst: "Slett utkast og fortsett",
+        kontekst: "AktivPlanSide-SletteUtkastForALageNyModal",
+      },
+      avbryt: {
+        komponentId: "avbryt-slett-utkast-knapp",
+        tekst: "Avbryt",
+        kontekst: "AktivPlanSide-SletteUtkastForALageNyModal",
+      },
+    },
+  },
+};

--- a/src/common/analytics/events-and-properties/skjema-events.ts
+++ b/src/common/analytics/events-and-properties/skjema-events.ts
@@ -1,0 +1,22 @@
+import {
+  SkjemaFullfortEvent,
+  SkjemaStegFullfortEvent,
+} from "@navikt/analytics-types";
+
+export const fyllUtPlanSkjemaStegFullfortEvent: SkjemaStegFullfortEvent = {
+  name: "skjema steg fullført",
+  properties: {
+    komponentId: "gaa-til-oppsummering-knapp",
+    skjemanavn: "Oppfølgingsplan",
+    steg: "fyll-ut-plan",
+  },
+};
+
+export const fyllUtPlanSkjemaFullfortEvent: SkjemaFullfortEvent = {
+  name: "skjema fullført",
+  properties: {
+    komponentId: "ferdigstill-oppfolgingsplan-knapp",
+    skjemanavn: "Oppfølgingsplan",
+    kontekst: "Oppsummering",
+  },
+};

--- a/src/common/analytics/logAnalyticsEvent.ts
+++ b/src/common/analytics/logAnalyticsEvent.ts
@@ -6,9 +6,11 @@ import { isLocalOrDemo } from "@/env-variables/envHelpers.ts";
 
 const logger = getAnalyticsInstance("syfo-oppfolgingsplan-frontend");
 
-export function logTaxonomyEvent<K extends EventName>(event: TaxonomyEvent<K>) {
+export function logAnalyticsEvent<K extends EventName>(
+  event: TaxonomyEvent<K>,
+) {
   if (isLocalOrDemo) {
-    console.log("Taxonomy event logged:", event);
+    console.log("Analytics event logged:", event);
     return;
   }
 

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/Buttons/AktivPlanButtons.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/Buttons/AktivPlanButtons.tsx
@@ -3,13 +3,14 @@
 import { startTransition, useActionState, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { HStack } from "@navikt/ds-react";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
 import { getAGOpprettNyPlanHref } from "@/common/route-hrefs";
 import { upsertUtkastWithAktivPlanServerAction } from "@/server/actions/upsertUtkastWithAktivPlan";
 import { FetchErrorAlert } from "@/ui/FetchErrorAlert";
 import { TrackedButton } from "@/ui/TrackedButton";
 import { VisPdfButton } from "../../Shared/Buttons/VisPdfButton";
-import { VilDuOverskriveUtkastModal } from "../AlleredeUtkastModaler/VilDuOverskriveUtkastMedInnholdModal";
-import { VilDuSletteUtkastModal } from "../AlleredeUtkastModaler/VilDuSletteUtkastModal";
+import { VilDuOverskriveUtkastForAEndrePlanModal } from "../HarAlleredeUtkastModaler/VilDuOverskriveUtkastForAEndrePlanModal";
+import { VilDuSletteUtkastForALageNyPlanModal } from "../HarAlleredeUtkastModaler/VilDuSletteUtkastForALageNyPlanModal";
 
 interface Props {
   planId: string;
@@ -25,8 +26,10 @@ export function AktivPlanButtons({
   const { push } = useRouter();
   const { narmesteLederId } = useParams<{ narmesteLederId: string }>();
 
-  const vilDuOverskriveUtkastModal = useRef<HTMLDialogElement | null>(null);
-  const vilDuSletteUtkastModal = useRef<HTMLDialogElement | null>(null);
+  const vilDuOverskriveUtkastMedInnholdFraAktivPlanModalRef =
+    useRef<HTMLDialogElement | null>(null);
+  const vilDuSletteUtkastForALageNyPlanModalRef =
+    useRef<HTMLDialogElement | null>(null);
 
   const [
     { error: upsertUtkastWithAktivPlanError },
@@ -38,7 +41,7 @@ export function AktivPlanButtons({
 
   function handleEndreOppfolgingsplanClick() {
     if (hasUtkast) {
-      vilDuOverskriveUtkastModal.current?.showModal();
+      vilDuOverskriveUtkastMedInnholdFraAktivPlanModalRef.current?.showModal();
     } else {
       startTransition(() => {
         upsertUtkastWithAktivPlanAction(narmesteLederId);
@@ -48,7 +51,7 @@ export function AktivPlanButtons({
 
   function handleNyPlanClick() {
     if (hasUtkast) {
-      vilDuSletteUtkastModal.current?.showModal();
+      vilDuSletteUtkastForALageNyPlanModalRef.current?.showModal();
     } else {
       push(getAGOpprettNyPlanHref(narmesteLederId));
     }
@@ -56,8 +59,12 @@ export function AktivPlanButtons({
 
   return (
     <>
-      <VilDuOverskriveUtkastModal ref={vilDuOverskriveUtkastModal} />
-      <VilDuSletteUtkastModal ref={vilDuSletteUtkastModal} />
+      <VilDuOverskriveUtkastForAEndrePlanModal
+        ref={vilDuOverskriveUtkastMedInnholdFraAktivPlanModalRef}
+      />
+      <VilDuSletteUtkastForALageNyPlanModal
+        ref={vilDuSletteUtkastForALageNyPlanModalRef}
+      />
 
       <HStack justify="space-between">
         <HStack gap="4">
@@ -66,11 +73,7 @@ export function AktivPlanButtons({
             variant="primary"
             onClick={handleEndreOppfolgingsplanClick}
             loading={isPendingUpsertUtkastWithAktivPlan}
-            tracking={{
-              komponentId: "endre-oppfolgingsplan-knapp",
-              tekst: "Endre oppfølgingsplanen",
-              kontekst: "AktivPlanSide",
-            }}
+            tracking={knappKlikket.aktivPlanSide.endreOppfolgingsplan}
           >
             Endre oppfølgingsplanen
           </TrackedButton>
@@ -79,11 +82,7 @@ export function AktivPlanButtons({
             variant="secondary"
             onClick={handleNyPlanClick}
             disabled={!userHasEditAccess}
-            tracking={{
-              komponentId: "lag-ny-oppfolgingsplan-knapp",
-              tekst: "Lag en ny plan",
-              kontekst: "AktivPlanSide",
-            }}
+            tracking={knappKlikket.aktivPlanSide.lagNyOppfolgingsplan}
           >
             Lag en ny plan
           </TrackedButton>

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/DelPlanMedLegeButtonAndStatus.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/DelPlanMedLegeButtonAndStatus.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Alert, HStack, VStack } from "@navikt/ds-react";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
 import { getFormattedDateAndTimeString } from "@/ui-helpers/dateAndTime";
 import { FetchErrorAlert } from "@/ui/FetchErrorAlert";
 import { TrackedButton } from "@/ui/TrackedButton";
@@ -36,11 +37,7 @@ export function DelPlanMedLegeButtonAndStatus({
               variant="primary"
               loading={isPendingDelMedLege}
               disabled={isDelButtonDisabled}
-              tracking={{
-                komponentId: "del-med-fastlege-knapp",
-                tekst: "Send til fastlege",
-                kontekst: "AktivPlanSide",
-              }}
+              tracking={knappKlikket.aktivPlanSide.delMedFastlege}
             >
               Send til fastlege
             </TrackedButton>

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/DelPlanMedVeilederButtonAndStatus.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/DelPlanMedVeilederButtonAndStatus.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Alert, HStack, VStack } from "@navikt/ds-react";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
 import { getFormattedDateAndTimeString } from "@/ui-helpers/dateAndTime";
 import { FetchErrorAlert } from "@/ui/FetchErrorAlert";
 import { TrackedButton } from "@/ui/TrackedButton";
@@ -36,11 +37,7 @@ export function DelPlanMedVeilederButtonAndStatus({
               variant="primary"
               loading={isPendingDelMedVeileder}
               disabled={isDelButtonDisabled}
-              tracking={{
-                komponentId: "del-med-nav-knapp",
-                tekst: "Send til Nav-veileder",
-                kontekst: "AktivPlanSide",
-              }}
+              tracking={knappKlikket.aktivPlanSide.delMedVeileder}
             >
               Send til Nav-veileder
             </TrackedButton>

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/HarAlleredeUtkastModaler/VilDuOverskriveUtkastForAEndrePlanModal.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/HarAlleredeUtkastModaler/VilDuOverskriveUtkastForAEndrePlanModal.tsx
@@ -1,7 +1,8 @@
 import { useActionState } from "react";
 import { useParams } from "next/navigation";
 import { BodyLong, Modal } from "@navikt/ds-react";
-import { slettUtkastAndRedirectToNyPlanServerAction } from "@/server/actions/slettUtkast";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
+import { upsertUtkastWithAktivPlanServerAction } from "@/server/actions/upsertUtkastWithAktivPlan";
 import { FetchErrorAlert } from "@/ui/FetchErrorAlert";
 import { TrackedButton } from "@/ui/TrackedButton";
 
@@ -9,11 +10,11 @@ interface Props {
   ref: React.RefObject<HTMLDialogElement | null>;
 }
 
-export function VilDuSletteUtkastModal({ ref }: Props) {
+export function VilDuOverskriveUtkastForAEndrePlanModal({ ref }: Props) {
   const { narmesteLederId } = useParams<{ narmesteLederId: string }>();
 
-  const [{ error }, slettUtkastAndRedirectAction, isPendingSlettUtkast] =
-    useActionState(slettUtkastAndRedirectToNyPlanServerAction, {
+  const [{ error }, overskrivUtkastAction, isPendingOverskrivUtkast] =
+    useActionState(upsertUtkastWithAktivPlanServerAction, {
       error: null,
     });
 
@@ -21,45 +22,39 @@ export function VilDuSletteUtkastModal({ ref }: Props) {
     <Modal
       ref={ref}
       header={{
-        heading: "Slett utkast?",
+        heading: "Erstatt utkast?",
       }}
       closeOnBackdropClick
     >
       <Modal.Body>
         <BodyLong>
           Du har allerede et utkast. Hvis du fortsetter vil utkastet ditt bli
-          slettet. Vil du fortsette?
+          erstattet med innholdet i denne planen. Vil du fortsette?
         </BodyLong>
 
         <FetchErrorAlert error={error} className="mt-4" />
       </Modal.Body>
 
       <Modal.Footer>
-        <form action={() => slettUtkastAndRedirectAction(narmesteLederId)}>
+        <form action={() => overskrivUtkastAction(narmesteLederId)}>
           <TrackedButton
             type="submit"
             variant="primary"
-            loading={isPendingSlettUtkast}
-            tracking={{
-              komponentId: "slett-utkast-og-fortsett-knapp",
-              tekst: "Slett utkast og fortsett",
-              kontekst: "vil-du-slette-utkast-modal",
-            }}
+            loading={isPendingOverskrivUtkast}
+            tracking={
+              knappKlikket.aktivPlanSide.overskriveUtkastForAEndreModal.bekreft
+            }
           >
-            Slett utkast og fortsett
+            Erstatt utkast og fortsett
           </TrackedButton>
         </form>
 
         <TrackedButton
           variant="secondary"
-          onClick={() => {
-            ref.current?.close();
-          }}
-          tracking={{
-            komponentId: "avbryt-slett-utkast-knapp",
-            tekst: "Avbryt",
-            kontekst: "vil-du-slette-utkast-modal",
-          }}
+          onClick={() => ref.current?.close()}
+          tracking={
+            knappKlikket.aktivPlanSide.overskriveUtkastForAEndreModal.avbryt
+          }
         >
           Avbryt
         </TrackedButton>

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/HarAlleredeUtkastModaler/VilDuSletteUtkastForALageNyPlanModal.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/HarAlleredeUtkastModaler/VilDuSletteUtkastForALageNyPlanModal.tsx
@@ -1,7 +1,8 @@
 import { useActionState } from "react";
 import { useParams } from "next/navigation";
 import { BodyLong, Modal } from "@navikt/ds-react";
-import { upsertUtkastWithAktivPlanServerAction } from "@/server/actions/upsertUtkastWithAktivPlan";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
+import { slettUtkastAndRedirectToNyPlanServerAction } from "@/server/actions/slettUtkast";
 import { FetchErrorAlert } from "@/ui/FetchErrorAlert";
 import { TrackedButton } from "@/ui/TrackedButton";
 
@@ -9,11 +10,11 @@ interface Props {
   ref: React.RefObject<HTMLDialogElement | null>;
 }
 
-export function VilDuOverskriveUtkastModal({ ref }: Props) {
+export function VilDuSletteUtkastForALageNyPlanModal({ ref }: Props) {
   const { narmesteLederId } = useParams<{ narmesteLederId: string }>();
 
-  const [{ error }, overskrivUtkastAction, isPendingOverskrivUtkast] =
-    useActionState(upsertUtkastWithAktivPlanServerAction, {
+  const [{ error }, slettUtkastAndRedirectAction, isPendingSlettUtkast] =
+    useActionState(slettUtkastAndRedirectToNyPlanServerAction, {
       error: null,
     });
 
@@ -21,43 +22,41 @@ export function VilDuOverskriveUtkastModal({ ref }: Props) {
     <Modal
       ref={ref}
       header={{
-        heading: "Erstatt utkast?",
+        heading: "Slett utkast?",
       }}
       closeOnBackdropClick
     >
       <Modal.Body>
         <BodyLong>
           Du har allerede et utkast. Hvis du fortsetter vil utkastet ditt bli
-          erstattet med innholdet i denne planen. Vil du fortsette?
+          slettet. Vil du fortsette?
         </BodyLong>
 
         <FetchErrorAlert error={error} className="mt-4" />
       </Modal.Body>
 
       <Modal.Footer>
-        <form action={() => overskrivUtkastAction(narmesteLederId)}>
+        <form action={() => slettUtkastAndRedirectAction(narmesteLederId)}>
           <TrackedButton
             type="submit"
             variant="primary"
-            loading={isPendingOverskrivUtkast}
-            tracking={{
-              komponentId: "erstatt-utkast-og-fortsett-knapp",
-              tekst: "Erstatt utkast og fortsett",
-              kontekst: "vil-du-overskrive-utkast-modal",
-            }}
+            loading={isPendingSlettUtkast}
+            tracking={
+              knappKlikket.aktivPlanSide.sletteUtkastForALageNyModal.bekreft
+            }
           >
-            Erstatt utkast og fortsett
+            Slett utkast og fortsett
           </TrackedButton>
         </form>
 
         <TrackedButton
           variant="secondary"
-          onClick={() => ref.current?.close()}
-          tracking={{
-            komponentId: "avbryt-erstatt-utkast-knapp",
-            tekst: "Avbryt",
-            kontekst: "vil-du-overskrive-utkast-modal",
+          onClick={() => {
+            ref.current?.close();
           }}
+          tracking={
+            knappKlikket.aktivPlanSide.sletteUtkastForALageNyModal.avbryt
+          }
         >
           Avbryt
         </TrackedButton>

--- a/src/components/FerdigstiltPlanSider/Shared/Buttons/TilbakeTilOversiktButtonForAG.tsx
+++ b/src/components/FerdigstiltPlanSider/Shared/Buttons/TilbakeTilOversiktButtonForAG.tsx
@@ -3,6 +3,7 @@
 import NextLink from "next/link";
 import { useParams } from "next/navigation";
 import { ChevronLeftIcon } from "@navikt/aksel-icons";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
 import { getAGOversiktHref } from "@/common/route-hrefs";
 import { TrackedButton } from "@/ui/TrackedButton";
 
@@ -17,11 +18,7 @@ export default function TilbakeTilOversiktButtonForAG() {
       icon={<ChevronLeftIcon aria-hidden />}
       href={getAGOversiktHref(narmesteLederId)}
       className="self-start"
-      tracking={{
-        komponentId: "tilbake-til-oversikt-knapp",
-        tekst: "Tilbake til oppfølgingsplaner",
-        kontekst: "FerdigstiltPlanSide",
-      }}
+      tracking={knappKlikket.ferdigstiltPlanSide.tilbakeTilOversikt}
     >
       Tilbake til oppfølgingsplaner
     </TrackedButton>

--- a/src/components/FerdigstiltPlanSider/Shared/Buttons/TilbakeTilOversiktButtonForSM.tsx
+++ b/src/components/FerdigstiltPlanSider/Shared/Buttons/TilbakeTilOversiktButtonForSM.tsx
@@ -2,6 +2,7 @@
 
 import NextLink from "next/link";
 import { ChevronLeftIcon } from "@navikt/aksel-icons";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
 import { getSMOversiktHref } from "@/common/route-hrefs";
 import { TrackedButton } from "@/ui/TrackedButton";
 
@@ -14,11 +15,7 @@ export default function TilbakeTilOversiktButtonForSM() {
       icon={<ChevronLeftIcon aria-hidden />}
       href={getSMOversiktHref()}
       className="self-start mb-8"
-      tracking={{
-        komponentId: "tilbake-til-oversikt-knapp",
-        tekst: "Tilbake til oppfølgingsplaner",
-        kontekst: "FerdigstiltPlanSide",
-      }}
+      tracking={knappKlikket.ferdigstiltPlanSide.tilbakeTilOversikt}
     >
       Tilbake til oppfølgingsplaner
     </TrackedButton>

--- a/src/components/FerdigstiltPlanSider/Shared/Buttons/VisPdfButton.tsx
+++ b/src/components/FerdigstiltPlanSider/Shared/Buttons/VisPdfButton.tsx
@@ -2,6 +2,7 @@
 
 import NextLink from "next/link";
 import { FilePdfIcon } from "@navikt/aksel-icons";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
 import { TrackedButton } from "@/ui/TrackedButton";
 
 interface Props {
@@ -17,11 +18,7 @@ export function VisPdfButton({ className, narmesteLederId, planId }: Props) {
       icon={<FilePdfIcon />}
       iconPosition="right"
       className={className}
-      tracking={{
-        komponentId: "vis-pdf-knapp",
-        tekst: "Vis PDF",
-        kontekst: "FerdigstiltPlanSide",
-      }}
+      tracking={knappKlikket.ferdigstiltPlanSide.visPdf}
       as={NextLink}
       href={`/api/${narmesteLederId}/pdf/${planId}`}
       target="_blank"

--- a/src/components/NyPlanSide/FyllUtPlanSteg/FyllUtPlanButtonsAndSavingInfo.tsx
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/FyllUtPlanButtonsAndSavingInfo.tsx
@@ -1,5 +1,6 @@
 import { ArrowRightIcon } from "@navikt/aksel-icons";
 import { Button, HStack, VStack } from "@navikt/ds-react";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
 import { FetchResultError } from "@/server/tokenXFetch/FetchResult";
 import { FetchErrorAlert } from "@/ui/FetchErrorAlert";
 import { TrackedButton } from "@/ui/TrackedButton";
@@ -43,11 +44,9 @@ export default function FyllUtPlanButtonsAndSavingInfo({
             onClick={onAvsluttOgFortsettSenereClick}
             loading={isPendingExit}
             disabled={isPendingProceed}
-            tracking={{
-              komponentId: "avslutt-og-fortsett-senere-knapp",
-              tekst: "Avslutt og fortsett senere",
-              kontekst: "NyPlanSide",
-            }}
+            tracking={
+              knappKlikket.nyPlanSide.fyllUtSteg.avsluttOgFortsettSenere
+            }
           >
             Avslutt og fortsett senere
           </TrackedButton>

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/field-components/FormDatePicker.tsx
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/field-components/FormDatePicker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DatePicker, useDatepicker } from "@navikt/ds-react";
-import { logTaxonomyEvent } from "@/common/logTaxonomyEvent";
+import { logAnalyticsEvent } from "@/common/analytics/logAnalyticsEvent";
 import { toDateStringInIsoFormat } from "@/utils/dateAndTime/dateUtils";
 import { useFieldContext } from "../hooks/form-context";
 
@@ -27,6 +27,7 @@ export default function FormDatePicker({
   className,
 }: Props) {
   const field = useFieldContext<string | undefined>();
+
   const { datepickerProps, inputProps } = useDatepicker({
     fromDate,
     toDate,
@@ -40,13 +41,7 @@ export default function FormDatePicker({
       // Og state value for feltet blir visst null. Og feilmelding som vises blir "Feltet må fylles ut."
       if (!isChangeDisabled && date) {
         const dateIsoString = toDateStringInIsoFormat(date);
-        logTaxonomyEvent({
-          name: "dato valgt",
-          properties: {
-            datoFelt: label,
-            datoVerdi: dateIsoString,
-          },
-        });
+        logAnalyticsDatoValgt(dateIsoString);
         field.handleChange(dateIsoString);
       }
     },
@@ -55,6 +50,16 @@ export default function FormDatePicker({
   const errorMessages = field.state.meta.errors
     .map((err) => err?.message)
     .join(", ");
+
+  function logAnalyticsDatoValgt(datoVerdi: string) {
+    logAnalyticsEvent({
+      name: "dato valgt",
+      properties: {
+        datoFelt: label,
+        datoVerdi,
+      },
+    });
+  }
 
   return (
     <DatePicker {...datepickerProps}>

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/field-components/FormRadioGroup.tsx
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/field-components/FormRadioGroup.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode } from "react";
 import { Radio, RadioGroup } from "@navikt/ds-react";
-import { logTaxonomyEvent } from "@/common/logTaxonomyEvent";
+import { logAnalyticsEvent } from "@/common/analytics/logAnalyticsEvent";
 import { useFieldContext } from "../hooks/form-context";
 
 interface Props {
@@ -34,7 +34,12 @@ export default function FormRadioGroup({
     .join(", ");
 
   const handleChange = (value: string) => {
-    logTaxonomyEvent({
+    logAnalyticsRadioValgEndret(value);
+    field.setValue(value);
+  };
+
+  function logAnalyticsRadioValgEndret(value: string) {
+    logAnalyticsEvent({
       name: "radio valg endret",
       properties: {
         komponentId: label,
@@ -42,8 +47,7 @@ export default function FormRadioGroup({
         antallAlternativer: options.length,
       },
     });
-    field.setValue(value);
-  };
+  }
 
   return (
     <RadioGroup

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/field-components/FormTextArea.tsx
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/field-components/FormTextArea.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Textarea } from "@navikt/ds-react";
+import { logAnalyticsEvent } from "@/common/analytics/logAnalyticsEvent";
 import { TEXT_FIELD_MAX_LENGTH } from "@/common/app-config";
-import { logTaxonomyEvent } from "@/common/logTaxonomyEvent.ts";
 import { useFieldContext } from "../hooks/form-context";
 
 interface Props {
@@ -30,6 +30,17 @@ export default function FormTextArea({
     .map((err) => err?.message)
     .join(", ");
 
+  function logAnalyticsTextareaUtfylt() {
+    logAnalyticsEvent({
+      name: "textarea utfylt",
+      properties: {
+        feltNavn: label,
+        harVerdi: field.state.value.length > 0,
+        tegnlengde: field.state.value.length,
+      },
+    });
+  }
+
   return (
     <Textarea
       id={field.name}
@@ -44,14 +55,7 @@ export default function FormTextArea({
         !isChangeDisabled ? field.handleChange(e.target.value) : null
       }
       onBlur={() => {
-        logTaxonomyEvent({
-          name: "textarea utfylt",
-          properties: {
-            feltNavn: label,
-            harVerdi: field.state.value.length > 0,
-            tegnlengde: field.state.value.length,
-          },
-        });
+        logAnalyticsTextareaUtfylt();
         field.handleBlur();
       }}
       readOnly={isReadOnly}

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useOppfolgingsplanForm.ts
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useOppfolgingsplanForm.ts
@@ -70,7 +70,7 @@ export default function useOppfolgingsplanForm({
         saveIfChangesAndProceedToOppsummering(value);
       } else if (meta.submitAction === "ferdigstill") {
         startFerdigstillPlanAction({
-          // We now know the form is valid when onSubmit runs, so we can
+          // We know the form is valid when onSubmit runs, so we can
           // safely assert the type, and that evalueringsDato is defined
           formValues: value as z.infer<typeof oppfolgingsplanFormUtfylltSchema>,
           evalueringsDatoIsoString: value.evalueringsDato!,

--- a/src/components/NyPlanSide/LagPlanVeiviser.tsx
+++ b/src/components/NyPlanSide/LagPlanVeiviser.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { Activity, use } from "react";
-import { logTaxonomyEvent } from "@/common/logTaxonomyEvent";
+import {
+  fyllUtPlanSkjemaFullfortEvent,
+  fyllUtPlanSkjemaStegFullfortEvent,
+} from "@/common/analytics/events-and-properties/skjema-events";
+import { logAnalyticsEvent } from "@/common/analytics/logAnalyticsEvent";
 import { ConvertedLagretUtkastData } from "@/schema/utkastResponseSchema";
 import FyllUtPlanSteg from "./FyllUtPlanSteg/FyllUtPlanSteg";
 import useOppfolgingsplanForm from "./FyllUtPlanSteg/form/hooks/useOppfolgingsplanForm";
@@ -40,6 +44,16 @@ export default function LagPlanVeiviser({ lagretUtkastPromise }: Props) {
     initialSistLagretTidspunkt,
   });
 
+  function handleFortsettTilOppsummering() {
+    logAnalyticsEvent(fyllUtPlanSkjemaStegFullfortEvent);
+    form.handleSubmit({ submitAction: "fortsettTilOppsummering" });
+  }
+
+  function handleFerdigstillPlan() {
+    logAnalyticsEvent(fyllUtPlanSkjemaFullfortEvent);
+    form.handleSubmit({ submitAction: "ferdigstill" });
+  }
+
   return (
     <section>
       <Activity
@@ -55,17 +69,7 @@ export default function LagPlanVeiviser({ lagretUtkastPromise }: Props) {
           onAvsluttOgFortsettSenereClick={() => {
             saveIfChangesAndExit();
           }}
-          onGoToOppsummeringClick={() => {
-            logTaxonomyEvent({
-              name: "skjema steg fullført",
-              properties: {
-                komponentId: "gaa-til-oppsummering-knapp",
-                skjemanavn: "Oppfølgingsplan",
-                steg: "fyll-ut-plan",
-              },
-            });
-            form.handleSubmit({ submitAction: "fortsettTilOppsummering" });
-          }}
+          onGoToOppsummeringClick={handleFortsettTilOppsummering}
           isFormReadOnly={!userHasEditAccess}
           lagreUtkastError={lagreUtkastError}
         />
@@ -78,17 +82,7 @@ export default function LagPlanVeiviser({ lagretUtkastPromise }: Props) {
           form={form}
           isPendingFerdigstillPlan={isPendingFerdigstillPlan}
           onGoBack={goBackToFyllUtPlanSteg}
-          onFerdigstillPlanClick={() => {
-            logTaxonomyEvent({
-              name: "skjema fullført",
-              properties: {
-                komponentId: "ferdigstill-oppfolgingsplan-knapp",
-                skjemanavn: "Oppfølgingsplan",
-                kontekst: "Oppsummering",
-              },
-            });
-            form.handleSubmit({ submitAction: "ferdigstill" });
-          }}
+          onFerdigstillPlanClick={handleFerdigstillPlan}
           ferdigstillPlanError={ferdigstillPlanError}
         />
       </Activity>

--- a/src/components/NyPlanSide/OppsummeringSteg/OppsummeringButtons.tsx
+++ b/src/components/NyPlanSide/OppsummeringSteg/OppsummeringButtons.tsx
@@ -2,6 +2,7 @@ import NextLink from "next/link";
 import { useParams } from "next/navigation";
 import { ArrowLeftIcon } from "@navikt/aksel-icons";
 import { Button, HStack, VStack } from "@navikt/ds-react";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
 import { getAGOversiktHref } from "@/common/route-hrefs";
 import { TrackedButton } from "@/ui/TrackedButton";
 
@@ -29,15 +30,12 @@ export default function OppsummeringButtons({
           icon={<ArrowLeftIcon aria-hidden />}
           onClick={onGoBackClick}
           disabled={isPendingFerdigstill}
-          tracking={{
-            komponentId: "ga-tilbake-fra-oppsummering-knapp",
-            tekst: "Gå tilbake",
-            kontekst: "Oppsummering",
-          }}
+          tracking={knappKlikket.nyPlanSide.oppsummeringSteg.gaTilbake}
         >
           Gå tilbake
         </TrackedButton>
 
+        {/* The ferdigstill user action is tracked elsewhere as SKJEMA_FULLFORT */}
         <Button
           variant="primary"
           onClick={onFerdigstillPlanClick}
@@ -49,27 +47,17 @@ export default function OppsummeringButtons({
 
       {isPendingFerdigstill ? (
         // Seperate because anchor cannot be disabled
-        <TrackedButton
-          variant="tertiary"
-          disabled
-          tracking={{
-            komponentId: "avslutt-og-fortsett-senere-knapp",
-            tekst: "Avslutt og fortsett senere",
-            kontekst: "NyPlanSide",
-          }}
-        >
+        <Button variant="tertiary" disabled>
           Avslutt og fortsett senere
-        </TrackedButton>
+        </Button>
       ) : (
         <TrackedButton
           variant="tertiary"
           as={NextLink}
           href={oversiktHref}
-          tracking={{
-            komponentId: "avslutt-og-fortsett-senere-knapp",
-            tekst: "Avslutt og fortsett senere",
-            kontekst: "Oppsummering",
-          }}
+          tracking={
+            knappKlikket.nyPlanSide.oppsummeringSteg.avsluttOgFortsettSenere
+          }
         >
           Avslutt og fortsett senere
         </TrackedButton>

--- a/src/components/OversiktSide/PlanListe/NyPlanButton.tsx
+++ b/src/components/OversiktSide/PlanListe/NyPlanButton.tsx
@@ -2,6 +2,7 @@
 
 import NextLink from "next/link";
 import { Box } from "@navikt/ds-react";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
 import { getAGOpprettNyPlanHref } from "@/common/route-hrefs";
 import { TrackedButton } from "@/ui/TrackedButton";
 
@@ -16,11 +17,7 @@ export function LagNyOppfolgingsplanButton({
         variant="primary"
         as={NextLink}
         href={getAGOpprettNyPlanHref(narmesteLederId)}
-        tracking={{
-          komponentId: "lag-ny-oppfolgingsplan-knapp",
-          tekst: "Lag en ny oppfølgingsplan",
-          kontekst: "OversiktSide",
-        }}
+        tracking={knappKlikket.oversiktSide.lagNyOppfolgingsplan}
       >
         Lag en ny oppfølgingsplan
       </TrackedButton>

--- a/src/components/OversiktSide/PlanListe/PlanLinkCard/AktivPlanLinkCard.tsx
+++ b/src/components/OversiktSide/PlanListe/PlanLinkCard/AktivPlanLinkCard.tsx
@@ -8,7 +8,7 @@ import {
   LinkCardFooter,
   LinkCardTitle,
 } from "@navikt/ds-react/LinkCard";
-import { logTaxonomyEvent } from "@/common/logTaxonomyEvent";
+import { logAnalyticsEvent } from "@/common/analytics/logAnalyticsEvent";
 import { FerdigstiltPlanMetadata } from "@/schema/ferdigstiltPlanMetadataSchema";
 import { getFormattedDateString } from "@/ui-helpers/dateAndTime";
 import PlanDelingStatusTags from "./PlanLinkCardFooterTags";
@@ -29,23 +29,22 @@ export default function AktivPlanLinkCard({
   linkCardTitle,
   href,
 }: Props) {
+  function logAnalyticsLinkCardClick() {
+    logAnalyticsEvent({
+      name: "linkcard klikket",
+      properties: {
+        tittel: "Ferdigstilt oppfølgingsplan",
+        destinasjon: href,
+        seksjon: "Ferdigstilte oppfølgingsplaner",
+      },
+    });
+  }
+
   return (
     <LinkCard className="bg-ax-bg-success-soft">
       <LinkCardTitle>
         <LinkCardAnchor asChild>
-          <NextLink
-            href={href}
-            onClick={() => {
-              logTaxonomyEvent({
-                name: "linkcard klikket",
-                properties: {
-                  tittel: "Ferdigstilt oppfølgingsplan",
-                  destinasjon: href,
-                  seksjon: "Ferdigstilte oppfølgingsplaner",
-                },
-              });
-            }}
-          >
+          <NextLink href={href} onClick={logAnalyticsLinkCardClick}>
             {linkCardTitle}
           </NextLink>
         </LinkCardAnchor>

--- a/src/components/OversiktSide/PlanListe/PlanLinkCard/TidligerePlanLinkCard.tsx
+++ b/src/components/OversiktSide/PlanListe/PlanLinkCard/TidligerePlanLinkCard.tsx
@@ -8,7 +8,7 @@ import {
   LinkCardFooter,
   LinkCardTitle,
 } from "@navikt/ds-react/LinkCard";
-import { logTaxonomyEvent } from "@/common/logTaxonomyEvent";
+import { logAnalyticsEvent } from "@/common/analytics/logAnalyticsEvent";
 import { FerdigstiltPlanMetadata } from "@/schema/ferdigstiltPlanMetadataSchema";
 import { getFormattedDateString } from "@/ui-helpers/dateAndTime";
 import PlanDelingStatusTags from "./PlanLinkCardFooterTags";
@@ -29,23 +29,22 @@ export default function TidligerePlanLinkCard({
   linkCardTitle,
   href,
 }: Props) {
+  function logAnalyticsLinkCardClick() {
+    logAnalyticsEvent({
+      name: "linkcard klikket",
+      properties: {
+        tittel: "Tidligere plan",
+        destinasjon: href,
+        seksjon: "Tidligere oppfølgingsplaner",
+      },
+    });
+  }
+
   return (
     <LinkCard className="bg-ax-bg-neutral-soft">
       <LinkCardTitle>
         <LinkCardAnchor asChild>
-          <NextLink
-            href={href}
-            onClick={() => {
-              logTaxonomyEvent({
-                name: "linkcard klikket",
-                properties: {
-                  tittel: "Tidligere plan",
-                  destinasjon: href,
-                  seksjon: "Tidligere oppfølgingsplaner",
-                },
-              });
-            }}
-          >
+          <NextLink href={href} onClick={logAnalyticsLinkCardClick}>
             {linkCardTitle}
           </NextLink>
         </LinkCardAnchor>

--- a/src/components/OversiktSide/PlanListe/PlanLinkCard/UtkastLinkCard.tsx
+++ b/src/components/OversiktSide/PlanListe/PlanLinkCard/UtkastLinkCard.tsx
@@ -8,7 +8,7 @@ import {
   LinkCardFooter,
   LinkCardTitle,
 } from "@navikt/ds-react/LinkCard";
-import { logTaxonomyEvent } from "@/common/logTaxonomyEvent";
+import { logAnalyticsEvent } from "@/common/analytics/logAnalyticsEvent";
 import { getAGOpprettNyPlanHref } from "@/common/route-hrefs";
 import { UtkastMetadata } from "@/schema/utkastMetadataSchema";
 import {
@@ -34,22 +34,24 @@ export default function UtkastLinkPanel({
     ? `i dag kl. ${getFormattedTimeString(sistLagretTidspunkt)}`
     : getFormattedDateAndTimeString(sistLagretTidspunkt);
 
+  function logAnalyticsLinkCardClick() {
+    logAnalyticsEvent({
+      name: "linkcard klikket",
+      properties: {
+        tittel: "Oppfølgingsplan under arbeid",
+        destinasjon: getAGOpprettNyPlanHref(narmesteLederId),
+        seksjon: "Oppfølgingsplan under arbeid",
+      },
+    });
+  }
+
   return (
     <LinkCard className="bg-ax-bg-brand-beige-soft">
       <LinkCardTitle>
         <LinkCardAnchor asChild>
           <NextLink
             href={getAGOpprettNyPlanHref(narmesteLederId)}
-            onClick={() => {
-              logTaxonomyEvent({
-                name: "linkcard klikket",
-                properties: {
-                  tittel: "Oppfølgingsplan under arbeid",
-                  destinasjon: getAGOpprettNyPlanHref(narmesteLederId),
-                  seksjon: "Oppfølgingsplan under arbeid",
-                },
-              });
-            }}
+            onClick={logAnalyticsLinkCardClick}
           >
             {linkCardTitle}
           </NextLink>

--- a/src/components/OversiktSide/PlanListe/SlettUtkast/SlettUtkastButtonAndModal.tsx
+++ b/src/components/OversiktSide/PlanListe/SlettUtkast/SlettUtkastButtonAndModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef } from "react";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
 import { TrackedButton } from "@/ui/TrackedButton";
 import { SlettUtkastModal } from "./SlettUtkastModal";
 
@@ -17,11 +18,7 @@ export function SlettUtkastButtonAndModal() {
         variant="tertiary"
         onClick={openModal}
         className="self-start"
-        tracking={{
-          komponentId: "apne-slett-utkast-modal-knapp",
-          tekst: "Slett utkast",
-          kontekst: "OversiktSide",
-        }}
+        tracking={knappKlikket.oversiktSide.slettUtkastModalTrigger}
       >
         Slett utkast
       </TrackedButton>

--- a/src/components/OversiktSide/PlanListe/SlettUtkast/SlettUtkastModal.tsx
+++ b/src/components/OversiktSide/PlanListe/SlettUtkast/SlettUtkastModal.tsx
@@ -1,4 +1,5 @@
 import { BodyLong, Modal } from "@navikt/ds-react";
+import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
 import { FetchErrorAlert } from "@/ui/FetchErrorAlert";
 import { TrackedButton } from "@/ui/TrackedButton";
 import useSlettUtkastAction from "./useSlettUtkastAction";
@@ -43,11 +44,7 @@ export function SlettUtkastModal({ modalRef }: Props) {
             type="submit"
             variant="primary"
             loading={isPendingSlettUtkast}
-            tracking={{
-              komponentId: "slett-utkast-modal-knapp",
-              tekst: "Slett utkast",
-              kontekst: "OversiktSide",
-            }}
+            tracking={knappKlikket.oversiktSide.slettUtkastModal.bekreft}
           >
             Slett utkast
           </TrackedButton>
@@ -58,11 +55,7 @@ export function SlettUtkastModal({ modalRef }: Props) {
           onClick={() => {
             modalRef.current?.close();
           }}
-          tracking={{
-            komponentId: "avbryt-slett-utkast-modal-knapp",
-            tekst: "Avbryt",
-            kontekst: "OversiktSide",
-          }}
+          tracking={knappKlikket.oversiktSide.slettUtkastModal.avbryt}
         >
           Avbryt
         </TrackedButton>

--- a/src/ui/TrackedButton.tsx
+++ b/src/ui/TrackedButton.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { Button, ButtonProps, OverridableComponent } from "@navikt/ds-react";
-import { logTaxonomyEvent } from "@/common/logTaxonomyEvent";
+import { logAnalyticsEvent } from "@/common/analytics/logAnalyticsEvent";
 
 interface TrackedButtonOwnProps {
+  /** Event properties to log for "knapp klikket" analytics event */
   tracking: {
     komponentId: string;
     tekst: string;
@@ -14,7 +15,7 @@ interface TrackedButtonOwnProps {
 export type TrackedButtonProps = ButtonProps & TrackedButtonOwnProps;
 
 export const TrackedButton = (({
-  tracking,
+  tracking: { komponentId, tekst, kontekst },
   onClick,
   ...props
 }: TrackedButtonProps) => {
@@ -22,12 +23,12 @@ export const TrackedButton = (({
     <Button
       {...props}
       onClick={(e) => {
-        logTaxonomyEvent({
+        logAnalyticsEvent({
           name: "knapp klikket",
           properties: {
-            komponentId: tracking.komponentId,
-            tekst: tracking.tekst,
-            kontekst: tracking.kontekst,
+            komponentId,
+            tekst,
+            kontekst,
             ...(props.variant ? { variant: props.variant } : {}),
           },
         });


### PR DESCRIPTION
Forslag til litt refaktorering av analytics kode.

Hovedpoenget er å få isolert analytics parametre og kode mer fra annen kode, særlig fra JSX kode. For lesbarhet.

Har flyttet button event property objekter til egen fil i ryddig struktur. Synes fordelene med å kunne se alle verdiene på et sted der + få renere JSX-kode, er større enn fordelen med å se de inline i hver button element.

Har gjort noe renaming, som logTaxonomyEvent -> logAnalyticsEvent. Synes "analytics" er mer dekkende ord i den sammenhengen. Mer inituitivt å forstå. Kan endre det tilbake hvis du er uenig.