### PR TITLE
Get delt tidspunkter from backend

### DIFF
--- a/src/server/actions/delPlanMedVeileder.ts
+++ b/src/server/actions/delPlanMedVeileder.ts
@@ -1,17 +1,22 @@
 "use server";
 
+import z from "zod";
 import { getEndpointDelMedVeilederForAG } from "@/common/backend-endpoints";
 import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import { now } from "@/utils/dateAndTime/dateUtils";
 import { TokenXTargetApi } from "../auth/tokenXExchange";
 import { simulateBackendDelay } from "../fetchData/mockData/simulateBackendDelay";
 import { FetchResultError } from "../tokenXFetch/FetchResult";
-import { tokenXFetchUpdate } from "../tokenXFetch/tokenXFetchUpdate";
+import { tokenXFetchUpdateWithResponse } from "../tokenXFetch/tokenXFetchUpdate";
 
 export type DelPlanMedVeilederActionState = {
   deltMedVeilederTidspunkt: string | null;
   errorDelMedVeileder: FetchResultError | null;
 };
+
+const delPlanMedVeilederResponseSchema = z.object({
+  deltMedVeilederTidspunkt: z.iso.datetime(),
+});
 
 export async function delPlanMedVeilederServerAction(
   narmesteLederId: string,
@@ -26,19 +31,20 @@ export async function delPlanMedVeilederServerAction(
     };
   }
 
-  const result = await tokenXFetchUpdate({
+  const { data, error } = await tokenXFetchUpdateWithResponse({
     targetApi: TokenXTargetApi.SYFO_OPPFOLGINGSPLAN_BACKEND,
     endpoint: getEndpointDelMedVeilederForAG(narmesteLederId, planId),
+    responseDataSchema: delPlanMedVeilederResponseSchema,
   });
 
-  if (result.error) {
+  if (error) {
     return {
       deltMedVeilederTidspunkt: null,
-      errorDelMedVeileder: result.error,
+      errorDelMedVeileder: error,
     };
   } else {
     return {
-      deltMedVeilederTidspunkt: now().toISOString(),
+      deltMedVeilederTidspunkt: data.deltMedVeilederTidspunkt,
       errorDelMedVeileder: null,
     };
   }

--- a/src/server/actions/lagreUtkast.ts
+++ b/src/server/actions/lagreUtkast.ts
@@ -17,7 +17,7 @@ import { FrontendErrorType } from "./FrontendErrorTypeEnum";
 import { isNonEmptyString } from "./serverActionsInputValidation";
 
 const lagreUtkastResponseSchema = z.object({
-  sistLagretTidspunkt: z.iso.datetime().nullable(),
+  sistLagretTidspunkt: z.iso.datetime(),
 });
 
 type LagreUtkastResponse = z.infer<typeof lagreUtkastResponseSchema>;


### PR DESCRIPTION
Krever deploy av https://github.com/navikt/syfo-oppfolgingsplan-backend/pull/167 først.

Vis tidspunkter fra backend i stedet for å beregne nåværende tidspunkt i frontend-server-kode. Dette er for at ikke vist tidspunkt skal endres med for eksempel et sekund. Uten dette kan det skje at bruker trykker feks "send til veileder", og så ser et tidspunkt (beregnet i frontend-kode), og så laster inn eller går inn på siden på nytt, og da ser et annet tidspunkt (som kommer fra backend).

Har testet at del med veileder fortsatt fungerer i dev. Har ikke fått testet del med lege, men dobbeltsjekket av navngivning for `deltMedLegeTidspunkt` i respons er lik mellom backend og frontend.