### PR TITLE
Improve a11y for required form fields

### DIFF
--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/OPFormFields.tsx
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/OPFormFields.tsx
@@ -24,6 +24,8 @@ const OPFormFields = withForm({
   props: {} as Props,
   render: ({ form, isChangeDisabled, isReadOnly }) => (
     <>
+      <BodyLong spacing>Alle felt må fylles ut.</BodyLong>
+
       <TextContentBox className="mb-4">
         <Heading level="2" size="medium" spacing>
           {formHeadings.arbeidsoppgaver}
@@ -35,6 +37,7 @@ const OPFormFields = withForm({
           <field.FormTextArea
             label={formLabels.typiskArbeidshverdag.label}
             description={formLabels.typiskArbeidshverdag.description}
+            isRequired
             isChangeDisabled={isChangeDisabled}
             isReadOnly={isReadOnly}
           />
@@ -45,6 +48,7 @@ const OPFormFields = withForm({
         {(field) => (
           <field.FormTextArea
             label={formLabels.arbeidsoppgaverSomKanUtfores.label}
+            isRequired
             isChangeDisabled={isChangeDisabled}
             isReadOnly={isReadOnly}
           />
@@ -55,6 +59,7 @@ const OPFormFields = withForm({
         {(field) => (
           <field.FormTextArea
             label={formLabels.arbeidsoppgaverSomIkkeKanUtfores.label}
+            isRequired
             isChangeDisabled={isChangeDisabled}
             isReadOnly={isReadOnly}
           />
@@ -84,6 +89,7 @@ const OPFormFields = withForm({
           <field.FormTextArea
             label={formLabels.tidligereTilrettelegging.label}
             description={formLabels.tidligereTilrettelegging.description}
+            isRequired
             isChangeDisabled={isChangeDisabled}
             isReadOnly={isReadOnly}
           />
@@ -95,6 +101,7 @@ const OPFormFields = withForm({
           <field.FormTextArea
             label={formLabels.tilretteleggingFremover.label}
             description={readMoreOmTilrettelegging}
+            isRequired
             isChangeDisabled={isChangeDisabled}
             isReadOnly={isReadOnly}
           />
@@ -106,6 +113,7 @@ const OPFormFields = withForm({
           <field.FormTextArea
             label={formLabels.annenTilrettelegging.label}
             description={formLabels.annenTilrettelegging.description}
+            isRequired
             isChangeDisabled={isChangeDisabled}
             isReadOnly={isReadOnly}
           />
@@ -116,6 +124,7 @@ const OPFormFields = withForm({
         {(field) => (
           <field.FormTextArea
             label={formLabels.hvordanFolgeOpp.label}
+            isRequired
             isChangeDisabled={isChangeDisabled}
             isReadOnly={isReadOnly}
           />
@@ -129,6 +138,7 @@ const OPFormFields = withForm({
             description={readMoreOmAEvaluerePlanen}
             fromDate={getTomorrowDayDate()}
             toDate={getOneYearFromNowDayDate()}
+            isRequired
             isChangeDisabled={isChangeDisabled}
             isReadOnly={isReadOnly}
             className="mb-8"
@@ -151,6 +161,7 @@ const OPFormFields = withForm({
                 label: "Nei",
               },
             ]}
+            isRequired
             isChangeDisabled={isChangeDisabled}
             isReadOnly={isReadOnly}
             className="mb-4"
@@ -168,6 +179,7 @@ const OPFormFields = withForm({
                   description={
                     formLabels.denAnsatteHarIkkeMedvirketBegrunnelse.description
                   }
+                  isRequired
                   isChangeDisabled={isChangeDisabled}
                 />
               )}

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/field-components/FormDatePicker.tsx
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/field-components/FormDatePicker.tsx
@@ -10,9 +10,10 @@ interface Props {
   description?: React.ReactNode;
   fromDate: Date;
   toDate: Date;
+  isRequired: boolean;
   isChangeDisabled?: boolean;
-  className?: string;
   isReadOnly?: boolean;
+  className?: string;
 }
 
 export default function FormDatePicker({
@@ -20,9 +21,10 @@ export default function FormDatePicker({
   description,
   fromDate,
   toDate,
+  isRequired,
   isChangeDisabled = false,
-  className,
   isReadOnly = false,
+  className,
 }: Props) {
   const field = useFieldContext<string | undefined>();
   const { datepickerProps, inputProps } = useDatepicker({
@@ -65,6 +67,7 @@ export default function FormDatePicker({
         error={errorMessages}
         className={className}
         readOnly={isReadOnly}
+        aria-required={isRequired}
       />
     </DatePicker>
   );

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/field-components/FormRadioGroup.tsx
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/field-components/FormRadioGroup.tsx
@@ -8,6 +8,7 @@ import { useFieldContext } from "../hooks/form-context";
 interface Props {
   label: string;
   description?: ReactNode;
+  isRequired: boolean;
   options: {
     value: string;
     label: string;
@@ -20,6 +21,7 @@ interface Props {
 export default function FormRadioGroup({
   label,
   description,
+  isRequired,
   options,
   isChangeDisabled = false,
   isReadOnly = false,
@@ -54,6 +56,7 @@ export default function FormRadioGroup({
       onBlur={field.handleBlur}
       className={className}
       disabled={isReadOnly}
+      aria-required={isRequired}
     >
       {options.map((option) => (
         <Radio key={option.value} value={option.value}>

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/field-components/FormTextArea.tsx
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/field-components/FormTextArea.tsx
@@ -10,6 +10,7 @@ interface Props {
   description?: React.ReactNode;
   minRows?: number;
   maxLength?: number;
+  isRequired: boolean;
   isChangeDisabled?: boolean;
   isReadOnly?: boolean;
 }
@@ -19,6 +20,7 @@ export default function FormTextArea({
   description,
   minRows,
   maxLength = TEXT_FIELD_MAX_LENGTH,
+  isRequired,
   isChangeDisabled = false,
   isReadOnly = false,
 }: Props) {
@@ -53,6 +55,7 @@ export default function FormTextArea({
         field.handleBlur();
       }}
       readOnly={isReadOnly}
+      aria-required={isRequired}
       className="mb-6"
     />
   );


### PR DESCRIPTION
"Alle felt må fylles ut" øverst, per råd fra Aksel i https://aksel.nav.no/god-praksis/artikler/obligatoriske-og-valgfrie-skjemafelter under "Skjemaer med bare obligatoriske felt".

Alle påkrevde felt merkes med `aria-required="true"`  som det står om under "Skjermleser og leselist".

Design kan se på "Alle felt må fylles ut" tekst.

<img width="904" height="628" alt="image" src="https://github.com/user-attachments/assets/de621350-a65b-4435-ae5e-988b7c7e84e5" />