### PR TITLE
feat(lumi): oppdater sykmeldt medvirkningssurvey

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@navikt/ds-css": "^8.7.0",
     "@navikt/ds-react": "^8.7.0",
     "@navikt/ds-tailwind": "^8.7.0",
-    "@navikt/lumi-survey": "^0.1.1",
+    "@navikt/lumi-survey": "^0.2.0",
     "@navikt/nav-dekoratoren-moduler": "^3.6.3",
     "@navikt/next-logger": "^4.5.1",
     "@navikt/oasis": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@navikt/ds-css": "^8.7.0",
     "@navikt/ds-react": "^8.7.0",
     "@navikt/ds-tailwind": "^8.7.0",
-    "@navikt/lumi-survey": "^0.2.0",
+    "@navikt/lumi-survey": "^0.3.0",
     "@navikt/nav-dekoratoren-moduler": "^3.6.3",
     "@navikt/next-logger": "^4.5.1",
     "@navikt/oasis": "^4.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^8.7.0
         version: 8.7.0
       '@navikt/lumi-survey':
-        specifier: ^0.2.0
-        version: 0.2.0(@navikt/ds-css@8.7.0)(@navikt/ds-react@8.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^0.3.0
+        version: 0.3.0(@navikt/ds-css@8.7.0)(@navikt/ds-react@8.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@navikt/nav-dekoratoren-moduler':
         specifier: ^3.6.3
         version: 3.6.3(csp-header@6.3.0)(html-react-parser@5.2.17(@types/react@19.2.14)(react@19.2.4))(jsdom@28.1.0)(react@19.2.4)
@@ -735,8 +735,8 @@ packages:
   '@navikt/ds-tokens@8.7.0':
     resolution: {integrity: sha512-YEeAzjJNFXwTrx2R9xf4Sue/sTCLaygFlJ0MVgje8Q5KzLiQSaVoK6gIGZHZ4wHVU6Q1uOAlIkdaHKlPvCfu7A==, tarball: https://npm.pkg.github.com/download/@navikt/ds-tokens/8.7.0/17a22dcaa2107ac81431db172701e0debe4e3fe3}
 
-  '@navikt/lumi-survey@0.2.0':
-    resolution: {integrity: sha512-xtDOKHC+OWWfSlt/eai5YZnPKm2Kba+1oqA6/gKhKrQ9UrelhhwfzVNOpnLIsMAlIQw/kheO/Zov0x1yzLfrpw==, tarball: https://npm.pkg.github.com/download/@navikt/lumi-survey/0.2.0/7dc970d846d93063832c5eef77829d8c06514eb8}
+  '@navikt/lumi-survey@0.3.0':
+    resolution: {integrity: sha512-iK/glrk2kB0drXg5UX21HA5uCD8nEo9Zpc4q9LAOstFU9Gw2y+L6e9/8JSl63zr4y+DFi1aGS5YCJ0bIDoan6g==, tarball: https://npm.pkg.github.com/download/@navikt/lumi-survey/0.3.0/d38bfd469f0c8f976ee2ee760660d98a5dfad480}
     peerDependencies:
       '@navikt/ds-css': '>=8'
       '@navikt/ds-react': '>=8'
@@ -2747,7 +2747,7 @@ snapshots:
 
   '@navikt/ds-tokens@8.7.0': {}
 
-  '@navikt/lumi-survey@0.2.0(@navikt/ds-css@8.7.0)(@navikt/ds-react@8.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@navikt/lumi-survey@0.3.0(@navikt/ds-css@8.7.0)(@navikt/ds-react@8.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@navikt/ds-css': 8.7.0
       '@navikt/ds-react': 8.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^8.7.0
         version: 8.7.0
       '@navikt/lumi-survey':
-        specifier: ^0.1.1
-        version: 0.1.1(@navikt/ds-css@8.7.0)(@navikt/ds-react@8.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^0.2.0
+        version: 0.2.0(@navikt/ds-css@8.7.0)(@navikt/ds-react@8.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@navikt/nav-dekoratoren-moduler':
         specifier: ^3.6.3
         version: 3.6.3(csp-header@6.3.0)(html-react-parser@5.2.17(@types/react@19.2.14)(react@19.2.4))(jsdom@28.1.0)(react@19.2.4)
@@ -725,6 +725,9 @@ packages:
       '@types/react': ^17.0.30 || ^18 || ^19
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@navikt/ds-tailwind@8.7.0':
     resolution: {integrity: sha512-J/ResgmF2WfjcDOoj/55Ero2Wfv1UZSxh+n/wpcnjAH+iEHhE/imPV042OLXi1/DLwcXUxkEg23gk7uHojTfKg==, tarball: https://npm.pkg.github.com/download/@navikt/ds-tailwind/8.7.0/99ec8b29ec7dbf154362952f78a512234c7a3ec3}
@@ -732,8 +735,8 @@ packages:
   '@navikt/ds-tokens@8.7.0':
     resolution: {integrity: sha512-YEeAzjJNFXwTrx2R9xf4Sue/sTCLaygFlJ0MVgje8Q5KzLiQSaVoK6gIGZHZ4wHVU6Q1uOAlIkdaHKlPvCfu7A==, tarball: https://npm.pkg.github.com/download/@navikt/ds-tokens/8.7.0/17a22dcaa2107ac81431db172701e0debe4e3fe3}
 
-  '@navikt/lumi-survey@0.1.1':
-    resolution: {integrity: sha512-84Uniy8b4CIwYsBuPIIdMHjilIq2261EvvRJU5mqLOwWtZo4ZfANjQ+oLcPQvYscqkZs2wD92ZobYtBQVLFvvg==, tarball: https://npm.pkg.github.com/download/@navikt/lumi-survey/0.1.1/ac3055547e8d91b984d3ca673d76cb068bb432ad}
+  '@navikt/lumi-survey@0.2.0':
+    resolution: {integrity: sha512-xtDOKHC+OWWfSlt/eai5YZnPKm2Kba+1oqA6/gKhKrQ9UrelhhwfzVNOpnLIsMAlIQw/kheO/Zov0x1yzLfrpw==, tarball: https://npm.pkg.github.com/download/@navikt/lumi-survey/0.2.0/7dc970d846d93063832c5eef77829d8c06514eb8}
     peerDependencies:
       '@navikt/ds-css': '>=8'
       '@navikt/ds-react': '>=8'
@@ -748,6 +751,9 @@ packages:
       html-react-parser: '>=5.x'
       jsdom: '>=16.x'
       react: '>=17.x'
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   '@navikt/next-logger@4.5.1':
     resolution: {integrity: sha512-qfiBT/kPK92sCVKGHlUeD2N9vDvJzEFpjn2qRVZiatQivD9IE+qRZwsdCpuvdU1Hylsc/fcF9/i03YQzXBf0iQ==, tarball: https://npm.pkg.github.com/download/@navikt/next-logger/4.5.1/e8c32873a7931396b0871c77b94673cbfb12d376}
@@ -2730,17 +2736,18 @@ snapshots:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@navikt/aksel-icons': 8.7.0
       '@navikt/ds-tokens': 8.7.0
-      '@types/react': 19.2.14
       date-fns: 4.1.0
       react: 19.2.4
       react-day-picker: 9.7.0(react@19.2.4)
       react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@navikt/ds-tailwind@8.7.0': {}
 
   '@navikt/ds-tokens@8.7.0': {}
 
-  '@navikt/lumi-survey@0.1.1(@navikt/ds-css@8.7.0)(@navikt/ds-react@8.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@navikt/lumi-survey@0.2.0(@navikt/ds-css@8.7.0)(@navikt/ds-react@8.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@navikt/ds-css': 8.7.0
       '@navikt/ds-react': 8.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2753,6 +2760,7 @@ snapshots:
       html-react-parser: 5.2.17(@types/react@19.2.14)(react@19.2.4)
       js-cookie: 3.0.5
       jsdom: 28.1.0
+    optionalDependencies:
       react: 19.2.4
 
   '@navikt/next-logger@4.5.1(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pino@10.3.1)':

--- a/src/app/sykmeldt/aktiv-plan/[planId]/page.tsx
+++ b/src/app/sykmeldt/aktiv-plan/[planId]/page.tsx
@@ -13,7 +13,10 @@ export default async function AktivPlanPageForSM({
     <Suspense fallback={<FerdigstiltPlanSkeleton />}>
       <AktivPlanForSM planId={planId} />
 
-      <Lumi feedbackId="Ny oppfølgingsplan - sykmeldt" survey={lumiSurveySM} />
+      <Lumi
+        feedbackId="Oppfølgingsplan medvirkning - sykmeldt"
+        survey={lumiSurveySM}
+      />
     </Suspense>
   );
 }

--- a/src/app/sykmeldt/aktiv-plan/[planId]/page.tsx
+++ b/src/app/sykmeldt/aktiv-plan/[planId]/page.tsx
@@ -15,6 +15,7 @@ export default async function AktivPlanPageForSM({
 
       <Lumi
         feedbackId="Oppfølgingsplan medvirkning - sykmeldt"
+        behavior={{ questionLayout: "steps", showProgress: true }}
         survey={lumiSurveySM}
       />
     </Suspense>

--- a/src/ui/Lumi/Lumi.tsx
+++ b/src/ui/Lumi/Lumi.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { VStack } from "@navikt/ds-react";
 import {
   type LumiSurveyBehavior,
   type LumiSurveyConfig,
   LumiSurveyDock,
   type LumiSurveyTransport,
 } from "@navikt/lumi-survey";
-import type { ReactElement } from "react";
 import { submitLumiSurveyFeedback } from "@/server/actions/submitLumiSurveyFeedback.ts";
 
 const transport: LumiSurveyTransport = {
@@ -22,30 +20,11 @@ interface Props {
   survey: LumiSurveyConfig;
 }
 
-const IntroBody = (): ReactElement => {
-  return (
-    <VStack gap="space-4">
-      <p>
-        Vi vil gjerne vite hvordan du opplevde å lage oppfølgingsplanen med
-        lederen din.
-      </p>
-      <p>
-        Svarene er anonyme. Håper du kan ta deg tid til å svare på noen
-        spørsmål.
-      </p>
-    </VStack>
-  );
-};
-
 export const Lumi = ({ feedbackId, behavior, survey }: Props) => (
   <LumiSurveyDock
     surveyId={feedbackId}
     survey={survey}
     transport={transport}
     behavior={behavior}
-    intro={{
-      title: "Hei!",
-      body: <IntroBody />,
-    }}
   />
 );

--- a/src/ui/Lumi/Lumi.tsx
+++ b/src/ui/Lumi/Lumi.tsx
@@ -19,5 +19,10 @@ interface Props {
 }
 
 export const Lumi = ({ feedbackId, survey }: Props) => (
-  <LumiSurveyDock surveyId={feedbackId} survey={survey} transport={transport} />
+  <LumiSurveyDock
+    surveyId={feedbackId}
+    survey={survey}
+    transport={transport}
+    behavior={{ questionLayout: "steps" }}
+  />
 );

--- a/src/ui/Lumi/Lumi.tsx
+++ b/src/ui/Lumi/Lumi.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { VStack } from "@navikt/ds-react";
 import {
+  type LumiSurveyBehavior,
   type LumiSurveyConfig,
   LumiSurveyDock,
   type LumiSurveyTransport,
 } from "@navikt/lumi-survey";
+import type { ReactElement } from "react";
 import { submitLumiSurveyFeedback } from "@/server/actions/submitLumiSurveyFeedback.ts";
 
 const transport: LumiSurveyTransport = {
@@ -15,14 +18,34 @@ const transport: LumiSurveyTransport = {
 
 interface Props {
   feedbackId: string;
+  behavior?: LumiSurveyBehavior;
   survey: LumiSurveyConfig;
 }
 
-export const Lumi = ({ feedbackId, survey }: Props) => (
+const IntroBody = (): ReactElement => {
+  return (
+    <VStack gap="space-4">
+      <p>
+        Vi vil gjerne vite hvordan du opplevde å lage oppfølgingsplanen med
+        lederen din.
+      </p>
+      <p>
+        Svarene er anonyme. Håper du kan ta deg tid til å svare på noen
+        spørsmål.
+      </p>
+    </VStack>
+  );
+};
+
+export const Lumi = ({ feedbackId, behavior, survey }: Props) => (
   <LumiSurveyDock
     surveyId={feedbackId}
     survey={survey}
     transport={transport}
-    behavior={{ questionLayout: "steps" }}
+    behavior={behavior}
+    intro={{
+      title: "Hei!",
+      body: <IntroBody />,
+    }}
   />
 );

--- a/src/ui/Lumi/lumiSurveySM.test.ts
+++ b/src/ui/Lumi/lumiSurveySM.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from "vitest";
+import { lumiSurveySM } from "./lumiSurveySM";
+
+test("uses the medvirkning survey configuration for sykmeldt", () => {
+  expect(lumiSurveySM.type).toBe("custom");
+  expect(lumiSurveySM.questions).toHaveLength(10);
+
+  expect(lumiSurveySM.questions).toEqual([
+    expect.objectContaining({
+      id: "opplevelse",
+      type: "rating",
+      variant: "emoji",
+      required: true,
+    }),
+    expect.objectContaining({
+      id: "samarbeid",
+      type: "singleChoice",
+      required: true,
+      options: [
+        { value: "sammen", label: "Vi satt sammen og lagde den" },
+        {
+          value: "snakket",
+          label: "Vi snakket sammen, og lederen skrev den etterpå",
+        },
+        {
+          value: "uten-meg",
+          label: "Lederen lagde den uten at vi snakket om den",
+        },
+        { value: "annet", label: "Annet" },
+      ],
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "opplevelse",
+        operator: "EXISTS",
+      },
+    }),
+    expect.objectContaining({
+      id: "samarbeid-annet",
+      type: "text",
+      required: false,
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "samarbeid",
+        operator: "EQ",
+        value: "annet",
+      },
+    }),
+    expect.objectContaining({
+      id: "behov",
+      type: "rating",
+      variant: "emoji",
+      required: true,
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "samarbeid",
+        operator: "EXISTS",
+      },
+    }),
+    expect.objectContaining({
+      id: "hva-savner-du",
+      type: "text",
+      required: false,
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "behov",
+        operator: "LT",
+        value: 4,
+      },
+    }),
+    expect.objectContaining({
+      id: "hva-fungerer",
+      type: "text",
+      required: false,
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "behov",
+        operator: "GT",
+        value: 3,
+      },
+    }),
+    expect.objectContaining({
+      id: "deling-kunnskap",
+      type: "singleChoice",
+      required: true,
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "behov",
+        operator: "EXISTS",
+      },
+    }),
+    expect.objectContaining({
+      id: "deling-holdning",
+      type: "singleChoice",
+      required: true,
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "deling-kunnskap",
+        operator: "EXISTS",
+      },
+    }),
+    expect.objectContaining({
+      id: "forbedring",
+      type: "singleChoice",
+      required: false,
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "deling-holdning",
+        operator: "EXISTS",
+      },
+    }),
+    expect.objectContaining({
+      id: "annet",
+      type: "text",
+      required: false,
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "deling-holdning",
+        operator: "EXISTS",
+      },
+    }),
+  ]);
+});

--- a/src/ui/Lumi/lumiSurveySM.test.ts
+++ b/src/ui/Lumi/lumiSurveySM.test.ts
@@ -3,7 +3,7 @@ import { lumiSurveySM } from "./lumiSurveySM";
 
 test("uses the medvirkning survey configuration for sykmeldt", () => {
   expect(lumiSurveySM.type).toBe("custom");
-  expect(lumiSurveySM.questions).toHaveLength(10);
+  expect(lumiSurveySM.questions).toHaveLength(4);
 
   expect(lumiSurveySM.questions).toEqual([
     expect.objectContaining({
@@ -17,106 +17,32 @@ test("uses the medvirkning survey configuration for sykmeldt", () => {
       type: "singleChoice",
       required: true,
       options: [
-        { value: "sammen", label: "Vi satt sammen og lagde den" },
+        { value: "sammen", label: "Ja, vi satt sammen og lagde den" },
         {
           value: "snakket",
-          label: "Vi snakket sammen, og lederen skrev den etterpå",
+          label: "Ja, vi snakket sammen, og lederen min lagde den etterpå",
         },
         {
           value: "uten-meg",
-          label: "Lederen lagde den uten at vi snakket om den",
+          label: "Nei, lederen min lagde den uten at vi snakket sammen",
         },
         { value: "annet", label: "Annet" },
       ],
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "opplevelse",
-        operator: "EXISTS",
-      },
-    }),
-    expect.objectContaining({
-      id: "samarbeid-annet",
-      type: "text",
-      required: false,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "samarbeid",
-        operator: "EQ",
-        value: "annet",
-      },
-    }),
-    expect.objectContaining({
-      id: "behov",
-      type: "rating",
-      variant: "emoji",
-      required: true,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "samarbeid",
-        operator: "EXISTS",
-      },
-    }),
-    expect.objectContaining({
-      id: "hva-savner-du",
-      type: "text",
-      required: false,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "behov",
-        operator: "LT",
-        value: 4,
-      },
-    }),
-    expect.objectContaining({
-      id: "hva-fungerer",
-      type: "text",
-      required: false,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "behov",
-        operator: "GT",
-        value: 3,
-      },
-    }),
-    expect.objectContaining({
-      id: "deling-kunnskap",
-      type: "singleChoice",
-      required: true,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "behov",
-        operator: "EXISTS",
-      },
     }),
     expect.objectContaining({
       id: "deling-holdning",
       type: "singleChoice",
       required: true,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "deling-kunnskap",
-        operator: "EXISTS",
-      },
-    }),
-    expect.objectContaining({
-      id: "forbedring",
-      type: "singleChoice",
-      required: false,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "deling-holdning",
-        operator: "EXISTS",
-      },
+      options: [
+        { value: "helt-greit", label: "Helt greit" },
+        { value: "greit", label: "Greit" },
+        { value: "ikke-greit", label: "Ikke greit" },
+      ],
     }),
     expect.objectContaining({
       id: "annet",
       type: "text",
       required: false,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "deling-holdning",
-        operator: "EXISTS",
-      },
     }),
   ]);
 });

--- a/src/ui/Lumi/lumiSurveySM.ts
+++ b/src/ui/Lumi/lumiSurveySM.ts
@@ -1,25 +1,207 @@
 import type { LumiSurveyConfig } from "@navikt/lumi-survey";
 
 export const lumiSurveySM: LumiSurveyConfig = {
-  type: "rating",
+  type: "custom",
   questions: [
     {
-      id: "plan-til-hjelp",
+      id: "opplevelse",
       type: "rating",
       variant: "emoji",
-      prompt: "Er oppfølgingsplanen til hjelp for deg?",
-      description: "Alle tilbakemeldinger er til stor nytte for oss",
+      required: true,
+      prompt: "Hvordan opplevde du å lage oppfølgingsplanen med lederen din?",
+      description:
+        "Vi vil gjerne vite mer om opplevelsen din. Svarene er anonyme.",
     },
     {
-      id: "begrunnelse",
+      id: "samarbeid",
+      type: "singleChoice",
+      required: true,
+      prompt: "Hvordan var samarbeidet om oppfølgingsplanen?",
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "opplevelse",
+        operator: "EXISTS",
+      },
+      options: [
+        {
+          value: "sammen",
+          label: "Vi satt sammen og lagde den",
+        },
+        {
+          value: "snakket",
+          label: "Vi snakket sammen, og lederen skrev den etterpå",
+        },
+        {
+          value: "uten-meg",
+          label: "Lederen lagde den uten at vi snakket om den",
+        },
+        {
+          value: "annet",
+          label: "Annet",
+        },
+      ],
+    },
+    {
+      id: "samarbeid-annet",
       type: "text",
-      prompt: "Legg gjerne til en begrunnelse",
-      description: "Alle tilbakemeldinger er til stor nytte for oss",
+      prompt: "Fortell gjerne mer",
       required: false,
-      minRows: 3,
+      minRows: 2,
       maxLength: 500,
       visibleIf: {
-        questionId: "plan-til-hjelp",
+        field: "ANSWER",
+        questionId: "samarbeid",
+        operator: "EQ",
+        value: "annet",
+      },
+    },
+    {
+      id: "behov",
+      type: "rating",
+      variant: "emoji",
+      required: true,
+      prompt: "Tar planen opp det som er viktig for deg?",
+      description:
+        "For eksempel tilrettelegging, arbeidstid eller arbeidsoppgaver",
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "samarbeid",
+        operator: "EXISTS",
+      },
+    },
+    {
+      id: "hva-savner-du",
+      type: "text",
+      prompt: "Hva savner du i planen?",
+      required: false,
+      minRows: 2,
+      maxLength: 500,
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "behov",
+        operator: "LT",
+        value: 4,
+      },
+    },
+    {
+      id: "hva-fungerer",
+      type: "text",
+      prompt: "Hva fungerer bra?",
+      required: false,
+      minRows: 2,
+      maxLength: 500,
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "behov",
+        operator: "GT",
+        value: 3,
+      },
+    },
+    {
+      id: "deling-kunnskap",
+      type: "singleChoice",
+      required: true,
+      prompt: "Visste du at lederen din kan dele planen med lege og Nav?",
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "behov",
+        operator: "EXISTS",
+      },
+      options: [
+        {
+          value: "ja",
+          label: "Ja",
+        },
+        {
+          value: "nei",
+          label: "Nei",
+        },
+        {
+          value: "usikker",
+          label: "Usikker",
+        },
+      ],
+    },
+    {
+      id: "deling-holdning",
+      type: "singleChoice",
+      required: true,
+      prompt: "Lederen din kan dele planen med lege og Nav uten at du godkjenner den. Hvor greit er dette for deg?",
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "deling-kunnskap",
+        operator: "EXISTS",
+      },
+      options: [
+        {
+          value: "helt-greit",
+          label: "Helt greit",
+        },
+        {
+          value: "ganske-greit",
+          label: "Ganske greit",
+        },
+        {
+          value: "verken-eller",
+          label: "Verken eller",
+        },
+        {
+          value: "lite-greit",
+          label: "Lite greit",
+        },
+        {
+          value: "ikke-greit",
+          label: "Ikke greit",
+        },
+      ],
+    },
+    {
+      id: "forbedring",
+      type: "singleChoice",
+      required: false,
+      prompt: "Hva ville vært viktigst for deg?",
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "deling-holdning",
+        operator: "EXISTS",
+      },
+      options: [
+        {
+          value: "lese-for-deling",
+          label: "Kunne lese planen før den deles videre",
+        },
+        {
+          value: "gi-innspill",
+          label: "Kunne gi flere innspill til planen",
+        },
+        {
+          value: "godkjenne",
+          label: "Måtte godkjenne planen før deling",
+        },
+        {
+          value: "si-fra",
+          label: "Lettere å si fra ved uenighet",
+        },
+        {
+          value: "ingen-endring",
+          label: "Ingen endring nødvendig",
+        },
+        {
+          value: "annet",
+          label: "Annet",
+        },
+      ],
+    },
+    {
+      id: "annet",
+      type: "text",
+      prompt: "Har du noe annet du vil si om planen?",
+      required: false,
+      minRows: 2,
+      maxLength: 500,
+      visibleIf: {
+        field: "ANSWER",
+        questionId: "deling-holdning",
         operator: "EXISTS",
       },
     },

--- a/src/ui/Lumi/lumiSurveySM.ts
+++ b/src/ui/Lumi/lumiSurveySM.ts
@@ -16,7 +16,7 @@ export const lumiSurveySM: LumiSurveyConfig = {
       id: "samarbeid",
       type: "singleChoice",
       required: true,
-      prompt: "Hvordan var samarbeidet om oppfølgingsplanen?",
+      prompt: "Hvordan samarbeidet dere om å lage oppfølgingsplanen?",
       visibleIf: {
         field: "ANSWER",
         questionId: "opplevelse",
@@ -126,7 +126,8 @@ export const lumiSurveySM: LumiSurveyConfig = {
       id: "deling-holdning",
       type: "singleChoice",
       required: true,
-      prompt: "Lederen din kan dele planen med lege og Nav uten at du godkjenner den. Hvor greit er dette for deg?",
+      prompt:
+        "Lederen din kan dele planen med lege og Nav uten at du godkjenner den. Hvor greit er dette for deg?",
       visibleIf: {
         field: "ANSWER",
         questionId: "deling-kunnskap",

--- a/src/ui/Lumi/lumiSurveySM.ts
+++ b/src/ui/Lumi/lumiSurveySM.ts
@@ -9,8 +9,6 @@ export const lumiSurveySM: LumiSurveyConfig = {
       variant: "emoji",
       required: true,
       prompt: "Hvordan opplevde du å lage oppfølgingsplanen med lederen din?",
-      description:
-        "Vi vil gjerne vite mer om opplevelsen din. Svarene er anonyme.",
     },
     {
       id: "samarbeid",

--- a/src/ui/Lumi/lumiSurveySM.ts
+++ b/src/ui/Lumi/lumiSurveySM.ts
@@ -8,115 +8,33 @@ export const lumiSurveySM: LumiSurveyConfig = {
       type: "rating",
       variant: "emoji",
       required: true,
-      prompt: "Hvordan opplevde du å lage oppfølgingsplanen med lederen din?",
+      prompt:
+        "Hvordan opplevde du samarbeidet med lederen din da oppfølgingsplanen ble laget?",
+      description:
+        "Svarene du sender inn er anonyme, og blir brukt til videreutvikling av oppfølgingsplanen.",
     },
     {
       id: "samarbeid",
       type: "singleChoice",
       required: true,
-      prompt: "Hvordan samarbeidet dere om å lage oppfølgingsplanen?",
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "opplevelse",
-        operator: "EXISTS",
-      },
+      prompt:
+        "Snakket du med lederen din om innholdet i planen før den ble laget?",
       options: [
         {
           value: "sammen",
-          label: "Vi satt sammen og lagde den",
+          label: "Ja, vi satt sammen og lagde den",
         },
         {
           value: "snakket",
-          label: "Vi snakket sammen, og lederen skrev den etterpå",
+          label: "Ja, vi snakket sammen, og lederen min lagde den etterpå",
         },
         {
           value: "uten-meg",
-          label: "Lederen lagde den uten at vi snakket om den",
+          label: "Nei, lederen min lagde den uten at vi snakket sammen",
         },
         {
           value: "annet",
           label: "Annet",
-        },
-      ],
-    },
-    {
-      id: "samarbeid-annet",
-      type: "text",
-      prompt: "Fortell gjerne mer",
-      required: false,
-      minRows: 2,
-      maxLength: 500,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "samarbeid",
-        operator: "EQ",
-        value: "annet",
-      },
-    },
-    {
-      id: "behov",
-      type: "rating",
-      variant: "emoji",
-      required: true,
-      prompt: "Tar planen opp det som er viktig for deg?",
-      description:
-        "For eksempel tilrettelegging, arbeidstid eller arbeidsoppgaver",
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "samarbeid",
-        operator: "EXISTS",
-      },
-    },
-    {
-      id: "hva-savner-du",
-      type: "text",
-      prompt: "Hva savner du i planen?",
-      required: false,
-      minRows: 2,
-      maxLength: 500,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "behov",
-        operator: "LT",
-        value: 4,
-      },
-    },
-    {
-      id: "hva-fungerer",
-      type: "text",
-      prompt: "Hva fungerer bra?",
-      required: false,
-      minRows: 2,
-      maxLength: 500,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "behov",
-        operator: "GT",
-        value: 3,
-      },
-    },
-    {
-      id: "deling-kunnskap",
-      type: "singleChoice",
-      required: true,
-      prompt: "Visste du at lederen din kan dele planen med lege og Nav?",
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "behov",
-        operator: "EXISTS",
-      },
-      options: [
-        {
-          value: "ja",
-          label: "Ja",
-        },
-        {
-          value: "nei",
-          label: "Nei",
-        },
-        {
-          value: "usikker",
-          label: "Usikker",
         },
       ],
     },
@@ -125,28 +43,15 @@ export const lumiSurveySM: LumiSurveyConfig = {
       type: "singleChoice",
       required: true,
       prompt:
-        "Lederen din kan dele planen med lege og Nav uten at du godkjenner den. Hvor greit er dette for deg?",
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "deling-kunnskap",
-        operator: "EXISTS",
-      },
+        "Hva synes du om at lederen din kan dele planen med fastlegen din og Nav uten at du godkjenner den?",
       options: [
         {
           value: "helt-greit",
           label: "Helt greit",
         },
         {
-          value: "ganske-greit",
-          label: "Ganske greit",
-        },
-        {
-          value: "verken-eller",
-          label: "Verken eller",
-        },
-        {
-          value: "lite-greit",
-          label: "Lite greit",
+          value: "greit",
+          label: "Greit",
         },
         {
           value: "ikke-greit",
@@ -155,54 +60,12 @@ export const lumiSurveySM: LumiSurveyConfig = {
       ],
     },
     {
-      id: "forbedring",
-      type: "singleChoice",
-      required: false,
-      prompt: "Hva ville vært viktigst for deg?",
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "deling-holdning",
-        operator: "EXISTS",
-      },
-      options: [
-        {
-          value: "lese-for-deling",
-          label: "Kunne lese planen før den deles videre",
-        },
-        {
-          value: "gi-innspill",
-          label: "Kunne gi flere innspill til planen",
-        },
-        {
-          value: "godkjenne",
-          label: "Måtte godkjenne planen før deling",
-        },
-        {
-          value: "si-fra",
-          label: "Lettere å si fra ved uenighet",
-        },
-        {
-          value: "ingen-endring",
-          label: "Ingen endring nødvendig",
-        },
-        {
-          value: "annet",
-          label: "Annet",
-        },
-      ],
-    },
-    {
       id: "annet",
       type: "text",
-      prompt: "Har du noe annet du vil si om planen?",
+      prompt: "Er det noe du vil legge til?",
       required: false,
-      minRows: 2,
+      minRows: 3,
       maxLength: 500,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "deling-holdning",
-        operator: "EXISTS",
-      },
     },
   ],
 };


### PR DESCRIPTION
## Beskrivelse

Erstatter den nåværende lumi-surveyen for sykmeldte med en ny medvirkningssurvey. Surveyen undersøker om den nye arbeidsflyten — der arbeidsgiver lager og deler oppfølgingsplanen uten godkjenning fra sykmeldt — gir en god opplevelse for de sykmeldte.

### Bakgrunn
En tilbakemelding fra sykmeldt viste at noen opplever det belastende at arbeidsgiver kan lage og dele planen uten involvering. Vi trenger data på hvor utbredt dette er.

### Endringer

**Sykmeldt survey (`lumiSurveySM.ts`)**
- Ny custom survey med 4 spørsmål (opplevelse, samarbeid, deling-holdning, fritekst)
- Step-basert layout med progressbar
- Nytt feedbackId for å separere data

**Lumi-komponent (`Lumi.tsx`)**
- `behavior` er nå konfigurerbart per survey via prop
- Fjernet hardcodet questionLayout

**Aktiv plan side (AG)**
- Ny `LagNyPlanModal` med upsert/slett-flyt
- Oppdaterte analytics-properties
- Fjernet gamle modaler (`VilDuSletteUtkast`, `VilDuOverskrive`)

**Dependency**
- Bumpet `@navikt/lumi-survey` til ^0.2.0 (progressbar-fiks for kjedet visibleIf)

## Issue

Closes #678

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt og automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)