### PR TITLE
fix(lint): fiks lint-feil fra biome 2.4.7-oppgradering

### DIFF
--- a/src/app/[narmesteLederId]/error.tsx
+++ b/src/app/[narmesteLederId]/error.tsx
@@ -22,7 +22,6 @@ export default function ErrorPage({
   const errorText = "Beklager! Det har oppstått en uventet feil";
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: role="status" is semantically correct for dynamic status messages
     <div className="flex max-w-3xl flex-col" role="status" aria-live="polite">
       <Image
         src={ERROR_PAGE_DAD_SVG}

--- a/src/app/sykmeldt/error.tsx
+++ b/src/app/sykmeldt/error.tsx
@@ -22,7 +22,6 @@ export default function ErrorPage({
   const errorText = "Beklager! Det har oppstått en uventet feil";
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: role="status" is semantically correct for dynamic status messages
     <div className="flex max-w-3xl flex-col" role="status" aria-live="polite">
       <Image
         src={ERROR_PAGE_DAD_SVG}

--- a/src/components/NyPlanSide/LagPlanVeiviser.buttonLagring.test.tsx
+++ b/src/components/NyPlanSide/LagPlanVeiviser.buttonLagring.test.tsx
@@ -15,11 +15,11 @@ import {
 
 // These date values are important for testing "Gå til oppsummering" behavior, since the
 // form must be valid to proceed to the next step.
-export const mockCurrentTime = new Date("2026-01-14T12:00:00Z");
+const mockCurrentTime = new Date("2026-01-14T12:00:00Z");
 // Must be between one day and one year after mockCurrentTime for form to be valid.
 const mockEvalueringsDatoFormValue = "2026-03-15";
 
-export function createValidFormContent(): OppfolgingsplanFormUtfyllt {
+function createValidFormContent(): OppfolgingsplanFormUtfyllt {
   return {
     typiskArbeidshverdag: "Kontorarbeid med møter",
     arbeidsoppgaverSomKanUtfores: "Skrivearbeid og telefonmøter",


### PR DESCRIPTION
## Hva er endret?

Fikser 4 lint-feil som ble introdusert da `@biomejs/biome` ble bumpa fra 2.4.6 til 2.4.7 (#686):

### Feil
- **2 errors**: `noExportsInTest` — unødvendige `export` i testfil (`LagPlanVeiviser.buttonLagring.test.tsx`)
- **2 warnings**: `suppressions/unused` — `biome-ignore`-kommentarer som ikke lenger har effekt fordi `useSemanticElements`-regelen ble fjernet/endret i biome 2.4.7

### Hvordan kom dette inn på main?
Dependabots biome-bump PR #686 hadde **`Test and lint: FAILURE`** i CI, men ble likevel merget av `teamesyfo-automerge`-appen. Automerge-workflowen sjekker kun dependabot-metadata (update-type), ikke om required checks faktisk passerer. Branch protection krever `next-app / Build for dev`, men ikke eksplisitt `Test and lint`.

### Tiltak
Vurder å legge til `next-app / Test and lint` som required status check i branch protection / merge queue-regler.

### Endrede filer
- `src/app/[narmesteLederId]/error.tsx` — fjernet ubrukt biome-ignore
- `src/app/sykmeldt/error.tsx` — fjernet ubrukt biome-ignore
- `src/components/NyPlanSide/LagPlanVeiviser.buttonLagring.test.tsx` — fjernet `export` fra testfil