### PR TITLE
fix(ci): use app token for merge queue auto-merge

### DIFF
--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -74,7 +74,15 @@ jobs:
 
           echo "✅ All files within hovmester sync scope"
 
-      - name: Approve and enable auto-merge
+      - name: Create GitHub App token for merge
+        if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'teamesyfo-automerge[bot]'
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: "2906300"
+          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
+
+      - name: Approve sync PR
         if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'teamesyfo-automerge[bot]'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -82,4 +90,12 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "Auto-approved: file scope verified ✅"
+
+      - name: Enable auto-merge
+        if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'teamesyfo-automerge[bot]'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
           gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash


### PR DESCRIPTION
## Problem

`hovmester-verify.yml` bruker `GITHUB_TOKEN` for `gh pr merge --auto --squash`. GitHub sin anti-rekursjon undertrykker `merge_group`-eventen når den er tilskrevet `GITHUB_TOKEN`, som gjør at merge queue-checks henger for alltid.

Bekreftet med bevis fra syfo-oppfolgingsplan-backend (PR #251 og #252) — auto-merge via `github-actions` henger alltid, manuell merge queue-tillegging fungerer.

## Løsning

Bruk GitHub App-tokenet (samme App som oppretter sync-PR-en) for merge-steget:

- **Approve** → fortsatt `GITHUB_TOKEN` (unngår self-approval-konflikt)
- **Merge** → App-token via `actions/create-github-app-token`

Allerede verifisert og deployet på syfo-oppfolgingsplan-backend — PR #252 gikk automatisk gjennom merge queue etter fixen.