### PR TITLE
feat(plan): vis stillingstittel og stillingsprosent i oppfølgingsplaner

### DIFF
--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/AktivPlanForAG.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/AktivPlanForAG.tsx
@@ -25,11 +25,14 @@ export default async function AktivPlanForAG({
   const [
     {
       employee,
+      organization,
       userHasEditAccess,
       oppfolgingsplan: {
         id: planId,
         evalueringsDato,
         ferdigstiltTidspunkt,
+        stillingstittel,
+        stillingsprosent,
         deltMedLegeTidspunkt,
         deltMedVeilederTidspunkt,
         content,
@@ -39,6 +42,7 @@ export default async function AktivPlanForAG({
   ] = await Promise.all([aktivPlanPromise, utkastPromise]);
 
   const hasUtkast = utkast !== null;
+  const orgName = organization.orgName ?? organization.orgNumber;
 
   return (
     <section>
@@ -50,12 +54,6 @@ export default async function AktivPlanForAG({
         >
           <AktivPlanHeadingAndTags employeeName={employee.name} />
 
-          <AktivPlanDetailsAG
-            nyligOprettet={nyligOpprettet}
-            ferdigstiltTidspunkt={ferdigstiltTidspunkt}
-            evalueringsDato={evalueringsDato}
-          />
-
           {userHasEditAccess && (
             <>
               <DelAktivPlanMedLegeEllerNav planId={planId} />
@@ -63,6 +61,15 @@ export default async function AktivPlanForAG({
               <AktivPlanButtons planId={planId} hasUtkast={hasUtkast} />
             </>
           )}
+
+          <AktivPlanDetailsAG
+            nyligOprettet={nyligOpprettet}
+            ferdigstiltTidspunkt={ferdigstiltTidspunkt}
+            evalueringsDato={evalueringsDato}
+            stillingstittel={stillingstittel}
+            stillingsprosent={stillingsprosent}
+            orgName={orgName}
+          />
 
           <FormSummaryFromSnapshot formSnapshot={content} />
 

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/AktivPlanForSM.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/AktivPlanForSM.tsx
@@ -17,6 +17,8 @@ export default async function AktivPlanForSM({ planId }: Props) {
     oppfolgingsplan: {
       evalueringsDato,
       ferdigstiltTidspunkt,
+      stillingstittel,
+      stillingsprosent,
       deltMedLegeTidspunkt,
       deltMedVeilederTidspunkt,
       content,
@@ -40,6 +42,9 @@ export default async function AktivPlanForSM({ planId }: Props) {
           <AktivPlanDetailsSM
             ferdigstiltTidspunkt={ferdigstiltTidspunkt}
             evalueringsDato={evalueringsDato}
+            stillingstittel={stillingstittel}
+            stillingsprosent={stillingsprosent}
+            orgName={arbeidsstedNavn}
           />
 
           <VisPdfButtonSM planId={planId} className="ml-auto" />

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/Details/AktivPlanDetailsAG.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/Details/AktivPlanDetailsAG.tsx
@@ -5,18 +5,31 @@ interface Props {
   nyligOprettet: boolean;
   ferdigstiltTidspunkt: string;
   evalueringsDato: string;
+  stillingstittel?: string | null;
+  stillingsprosent?: number | null;
+  orgName: string;
 }
 
 export function AktivPlanDetailsAG({
   nyligOprettet,
   ferdigstiltTidspunkt,
   evalueringsDato,
+  stillingstittel,
+  stillingsprosent,
+  orgName,
 }: Props) {
   const evalueringsDatoInfo = (
     <BodyShort size="medium">
       Evalueringsdato: {getFormattedDateString(evalueringsDato)}
     </BodyShort>
   );
+
+  const stillingsInfo = stillingstittel ? (
+    <BodyShort size="medium">
+      Stilling: {stillingstittel} i {orgName}
+      {stillingsprosent != null && ` i ${stillingsprosent}% stilling`}
+    </BodyShort>
+  ) : null;
 
   return nyligOprettet ? (
     <VStack className="gap-8">
@@ -25,6 +38,7 @@ export function AktivPlanDetailsAG({
       </Alert>
 
       {evalueringsDatoInfo}
+      {stillingsInfo}
     </VStack>
   ) : (
     <VStack className="gap-4">
@@ -33,6 +47,7 @@ export function AktivPlanDetailsAG({
       </BodyShort>
 
       {evalueringsDatoInfo}
+      {stillingsInfo}
     </VStack>
   );
 }

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/Details/AktivPlanDetailsAG.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/Details/AktivPlanDetailsAG.tsx
@@ -5,8 +5,8 @@ interface Props {
   nyligOprettet: boolean;
   ferdigstiltTidspunkt: string;
   evalueringsDato: string;
-  stillingstittel?: string | null;
-  stillingsprosent?: number | null;
+  stillingstittel: string | null;
+  stillingsprosent: number | null;
   orgName: string;
 }
 
@@ -32,7 +32,7 @@ export function AktivPlanDetailsAG({
   ) : null;
 
   return nyligOprettet ? (
-    <VStack className="gap-8">
+    <VStack gap="space-8">
       <Alert variant="success" size="medium">
         Oppfølgingsplanen er ferdigstilt og delt med den ansatte.
       </Alert>
@@ -41,7 +41,7 @@ export function AktivPlanDetailsAG({
       {stillingsInfo}
     </VStack>
   ) : (
-    <VStack className="gap-4">
+    <VStack gap="space-4">
       <BodyShort size="medium">
         Opprettet dato: {getFormattedDateString(ferdigstiltTidspunkt)}
       </BodyShort>

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/Details/AktivPlanDetailsAG.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/Details/AktivPlanDetailsAG.tsx
@@ -1,5 +1,6 @@
 import { Alert, BodyShort, VStack } from "@navikt/ds-react";
 import { getFormattedDateString } from "@/ui-helpers/dateAndTime";
+import { StillingsInfo } from "../../Shared/StillingsInfo";
 
 interface Props {
   nyligOprettet: boolean;
@@ -24,13 +25,6 @@ export function AktivPlanDetailsAG({
     </BodyShort>
   );
 
-  const stillingsInfo = stillingstittel ? (
-    <BodyShort size="medium">
-      Stilling: {stillingstittel} i {orgName}
-      {stillingsprosent != null && ` i ${stillingsprosent}% stilling`}
-    </BodyShort>
-  ) : null;
-
   return nyligOprettet ? (
     <VStack gap="space-8">
       <Alert variant="success" size="medium">
@@ -38,7 +32,11 @@ export function AktivPlanDetailsAG({
       </Alert>
 
       {evalueringsDatoInfo}
-      {stillingsInfo}
+      <StillingsInfo
+        stillingstittel={stillingstittel}
+        stillingsprosent={stillingsprosent}
+        orgName={orgName}
+      />
     </VStack>
   ) : (
     <VStack gap="space-4">
@@ -47,7 +45,11 @@ export function AktivPlanDetailsAG({
       </BodyShort>
 
       {evalueringsDatoInfo}
-      {stillingsInfo}
+      <StillingsInfo
+        stillingstittel={stillingstittel}
+        stillingsprosent={stillingsprosent}
+        orgName={orgName}
+      />
     </VStack>
   );
 }

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/Details/AktivPlanDetailsSM.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/Details/AktivPlanDetailsSM.tsx
@@ -1,5 +1,6 @@
 import { BodyShort, VStack } from "@navikt/ds-react";
 import { getFormattedDateString } from "@/ui-helpers/dateAndTime";
+import { StillingsInfo } from "../../Shared/StillingsInfo";
 
 interface Props {
   ferdigstiltTidspunkt: string;
@@ -24,12 +25,11 @@ export function AktivPlanDetailsSM({
       <BodyShort size="medium">
         Dato for evaluering: {getFormattedDateString(evalueringsDato)}
       </BodyShort>
-      {stillingstittel && (
-        <BodyShort size="medium">
-          Stilling: {stillingstittel} i {orgName}
-          {stillingsprosent != null && ` i ${stillingsprosent}% stilling`}
-        </BodyShort>
-      )}
+      <StillingsInfo
+        stillingstittel={stillingstittel}
+        stillingsprosent={stillingsprosent}
+        orgName={orgName}
+      />
     </VStack>
   );
 }

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/Details/AktivPlanDetailsSM.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/Details/AktivPlanDetailsSM.tsx
@@ -4,8 +4,8 @@ import { getFormattedDateString } from "@/ui-helpers/dateAndTime";
 interface Props {
   ferdigstiltTidspunkt: string;
   evalueringsDato: string;
-  stillingstittel?: string | null;
-  stillingsprosent?: number | null;
+  stillingstittel: string | null;
+  stillingsprosent: number | null;
   orgName: string;
 }
 

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/Details/AktivPlanDetailsSM.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/Details/AktivPlanDetailsSM.tsx
@@ -4,11 +4,17 @@ import { getFormattedDateString } from "@/ui-helpers/dateAndTime";
 interface Props {
   ferdigstiltTidspunkt: string;
   evalueringsDato: string;
+  stillingstittel?: string | null;
+  stillingsprosent?: number | null;
+  orgName: string;
 }
 
 export function AktivPlanDetailsSM({
   ferdigstiltTidspunkt,
   evalueringsDato,
+  stillingstittel,
+  stillingsprosent,
+  orgName,
 }: Props) {
   return (
     <VStack gap="space-4">
@@ -18,6 +24,12 @@ export function AktivPlanDetailsSM({
       <BodyShort size="medium">
         Dato for evaluering: {getFormattedDateString(evalueringsDato)}
       </BodyShort>
+      {stillingstittel && (
+        <BodyShort size="medium">
+          Stilling: {stillingstittel} i {orgName}
+          {stillingsprosent != null && ` i ${stillingsprosent}% stilling`}
+        </BodyShort>
+      )}
     </VStack>
   );
 }

--- a/src/components/FerdigstiltPlanSider/Shared/StillingsInfo.tsx
+++ b/src/components/FerdigstiltPlanSider/Shared/StillingsInfo.tsx
@@ -1,0 +1,22 @@
+import { BodyShort } from "@navikt/ds-react";
+
+interface Props {
+  stillingstittel: string | null;
+  stillingsprosent: number | null;
+  orgName: string;
+}
+
+export function StillingsInfo({
+  stillingstittel,
+  stillingsprosent,
+  orgName,
+}: Props) {
+  if (!stillingstittel) return null;
+
+  return (
+    <BodyShort size="medium">
+      Stilling: {stillingstittel} i {orgName}
+      {stillingsprosent != null && ` i ${stillingsprosent}% stilling`}
+    </BodyShort>
+  );
+}

--- a/src/components/FerdigstiltPlanSider/TidligerePlanSide/Details/TidligerePlanDetails.tsx
+++ b/src/components/FerdigstiltPlanSider/TidligerePlanSide/Details/TidligerePlanDetails.tsx
@@ -9,6 +9,9 @@ interface Props {
   evalueringsDato: string;
   deltMedLegeTidspunkt: string | null;
   deltMedVeilederTidspunkt: string | null;
+  stillingstittel?: string | null;
+  stillingsprosent?: number | null;
+  orgName: string;
 }
 
 export function TidligerePlanDetails({
@@ -16,6 +19,9 @@ export function TidligerePlanDetails({
   evalueringsDato,
   deltMedLegeTidspunkt,
   deltMedVeilederTidspunkt,
+  stillingstittel,
+  stillingsprosent,
+  orgName,
 }: Props) {
   return (
     <VStack className="gap-4">
@@ -27,6 +33,13 @@ export function TidligerePlanDetails({
         <BodyShort size="medium">
           Evalueringsdato: {getFormattedDateString(evalueringsDato)}
         </BodyShort>
+
+        {stillingstittel && (
+          <BodyShort size="medium">
+            Stilling: {stillingstittel} i {orgName}
+            {stillingsprosent != null && ` i ${stillingsprosent}% stilling`}
+          </BodyShort>
+        )}
       </VStack>
       <VStack gap="space-8">
         {deltMedLegeTidspunkt && (

--- a/src/components/FerdigstiltPlanSider/TidligerePlanSide/Details/TidligerePlanDetails.tsx
+++ b/src/components/FerdigstiltPlanSider/TidligerePlanSide/Details/TidligerePlanDetails.tsx
@@ -3,6 +3,7 @@ import {
   getFormattedDateAndTimeString,
   getFormattedDateString,
 } from "@/ui-helpers/dateAndTime";
+import { StillingsInfo } from "../../Shared/StillingsInfo";
 
 interface Props {
   ferdigstiltTidspunkt: string;
@@ -34,12 +35,11 @@ export function TidligerePlanDetails({
           Evalueringsdato: {getFormattedDateString(evalueringsDato)}
         </BodyShort>
 
-        {stillingstittel && (
-          <BodyShort size="medium">
-            Stilling: {stillingstittel} i {orgName}
-            {stillingsprosent != null && ` i ${stillingsprosent}% stilling`}
-          </BodyShort>
-        )}
+        <StillingsInfo
+          stillingstittel={stillingstittel}
+          stillingsprosent={stillingsprosent}
+          orgName={orgName}
+        />
       </VStack>
       <VStack gap="space-8">
         {deltMedLegeTidspunkt && (

--- a/src/components/FerdigstiltPlanSider/TidligerePlanSide/Details/TidligerePlanDetails.tsx
+++ b/src/components/FerdigstiltPlanSider/TidligerePlanSide/Details/TidligerePlanDetails.tsx
@@ -9,8 +9,8 @@ interface Props {
   evalueringsDato: string;
   deltMedLegeTidspunkt: string | null;
   deltMedVeilederTidspunkt: string | null;
-  stillingstittel?: string | null;
-  stillingsprosent?: number | null;
+  stillingstittel: string | null;
+  stillingsprosent: number | null;
   orgName: string;
 }
 
@@ -24,7 +24,7 @@ export function TidligerePlanDetails({
   orgName,
 }: Props) {
   return (
-    <VStack className="gap-4">
+    <VStack gap="space-4">
       <VStack gap="space-8">
         <BodyShort size="medium">
           Opprettet dato: {getFormattedDateString(ferdigstiltTidspunkt)}

--- a/src/components/FerdigstiltPlanSider/TidligerePlanSide/TidligerePlanForAG.tsx
+++ b/src/components/FerdigstiltPlanSider/TidligerePlanSide/TidligerePlanForAG.tsx
@@ -17,9 +17,12 @@ export default async function TidligerePlanForAG({
 }: Props) {
   const {
     employee,
+    organization,
     oppfolgingsplan: {
       evalueringsDato,
       ferdigstiltTidspunkt,
+      stillingstittel,
+      stillingsprosent,
       deltMedLegeTidspunkt,
       deltMedVeilederTidspunkt,
       content,
@@ -28,6 +31,7 @@ export default async function TidligerePlanForAG({
 
   const isDeltMedLege = Boolean(deltMedLegeTidspunkt);
   const isDeltMedVeileder = Boolean(deltMedVeilederTidspunkt);
+  const orgName = organization.orgName ?? organization.orgNumber;
 
   return (
     <section>
@@ -44,6 +48,9 @@ export default async function TidligerePlanForAG({
             evalueringsDato={evalueringsDato}
             deltMedLegeTidspunkt={deltMedLegeTidspunkt}
             deltMedVeilederTidspunkt={deltMedVeilederTidspunkt}
+            stillingstittel={stillingstittel}
+            stillingsprosent={stillingsprosent}
+            orgName={orgName}
           />
 
           <HStack justify="end">

--- a/src/components/FerdigstiltPlanSider/TidligerePlanSide/TidligerePlanForSM.tsx
+++ b/src/components/FerdigstiltPlanSider/TidligerePlanSide/TidligerePlanForSM.tsx
@@ -17,6 +17,8 @@ export default async function TidligerePlanForSM({ planId }: Props) {
     oppfolgingsplan: {
       evalueringsDato,
       ferdigstiltTidspunkt,
+      stillingstittel,
+      stillingsprosent,
       deltMedLegeTidspunkt,
       deltMedVeilederTidspunkt,
       content,
@@ -40,6 +42,9 @@ export default async function TidligerePlanForSM({ planId }: Props) {
           <AktivPlanDetailsSM
             ferdigstiltTidspunkt={ferdigstiltTidspunkt}
             evalueringsDato={evalueringsDato}
+            stillingstittel={stillingstittel}
+            stillingsprosent={stillingsprosent}
+            orgName={arbeidsstedNavn}
           />
 
           <VisPdfButtonSM planId={planId} className="ml-auto" />

--- a/src/schema/ferdigstiltPlanMetadataSchema.ts
+++ b/src/schema/ferdigstiltPlanMetadataSchema.ts
@@ -5,6 +5,8 @@ export const ferdigstiltPlanMetadataSchema = z.object({
   evalueringsDato: z.iso.date(),
   deltMedLegeTidspunkt: z.iso.datetime().nullable(),
   deltMedVeilederTidspunkt: z.iso.datetime().nullable(),
+  stillingstittel: z.string().min(1).nullish(),
+  stillingsprosent: z.number().nullish(),
 });
 
 export type FerdigstiltPlanMetadata = z.infer<

--- a/src/schema/ferdigstiltPlanMetadataSchema.ts
+++ b/src/schema/ferdigstiltPlanMetadataSchema.ts
@@ -5,8 +5,8 @@ export const ferdigstiltPlanMetadataSchema = z.object({
   evalueringsDato: z.iso.date(),
   deltMedLegeTidspunkt: z.iso.datetime().nullable(),
   deltMedVeilederTidspunkt: z.iso.datetime().nullable(),
-  stillingstittel: z.string().min(1).nullish(),
-  stillingsprosent: z.number().nullish(),
+  stillingstittel: z.string().min(1).nullable(),
+  stillingsprosent: z.number().nullable(),
 });
 
 export type FerdigstiltPlanMetadata = z.infer<

--- a/src/server/fetchData/mockData/mockPlanerData.ts
+++ b/src/server/fetchData/mockData/mockPlanerData.ts
@@ -19,6 +19,8 @@ export const mockAktivPlanData: OppfolgingsplanMetadata = {
   // deltMedLegeTidspunkt: getDayjsDateFromIsoString("2025-10-25T09:03:00Z"),
   deltMedVeilederTidspunkt: null,
   //deltMedVeilederTidspunkt: "2025-10-25T09:27:00Z",
+  stillingstittel: "Brødkontrollør",
+  stillingsprosent: 50,
   organization: mockOrganization,
 };
 
@@ -29,6 +31,8 @@ export const mockTidligerePlanerData: OppfolgingsplanMetadata[] = [
     evalueringsDato: "2025-08-31",
     deltMedVeilederTidspunkt: null,
     deltMedLegeTidspunkt: "2025-05-20T14:30:00Z",
+    stillingstittel: "Rådgiver",
+    stillingsprosent: 100,
     organization: mockOrganization,
   },
   {
@@ -37,6 +41,8 @@ export const mockTidligerePlanerData: OppfolgingsplanMetadata[] = [
     evalueringsDato: "2025-05-12",
     deltMedVeilederTidspunkt: "2025-01-15T10:28:00Z",
     deltMedLegeTidspunkt: "2025-01-20T11:52:00Z",
+    stillingstittel: null,
+    stillingsprosent: null,
     organization: mockOrganization,
   },
 ];


### PR DESCRIPTION
## Beskrivelse

Viser stillingstittel og stillingsprosent i oppfølgingsplanen — for AG og SM, aktive og historiske planer.

**Format:** `Stilling: {tittel} i {orgName} i {prosent}% stilling`

Null-håndtering: planer opprettet før endringen viser ingen stillingsrad. Stillingsprosent vises kun når den finnes.

Layout-endring i AG aktiv plan: delingsboks og knapper flyttes over infotekst-bolken (matcher Figma).

## Endringer

- `ferdigstiltPlanMetadataSchema.ts`: `stillingstittel` (.string().min(1).nullish()) og `stillingsprosent` (.number().nullish())
- `mockPlanerData.ts`: Mock-verdier inkl. historisk plan med null
- `AktivPlanDetailsAG.tsx`: Stillingsrad med null-håndtering
- `AktivPlanDetailsSM.tsx`: Stillingsrad med null-håndtering
- `TidligerePlanDetails.tsx`: Stillingsrad med null-håndtering
- `AktivPlanForAG.tsx`: Thread props + layout-reorder
- `AktivPlanForSM.tsx`: Thread stilling-props
- `TidligerePlanForAG.tsx`: Thread stilling-props + destructure organization
- `TidligerePlanForSM.tsx`: Thread stilling-props

## Issue

Closes #728

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)