### PR TITLE
refactor(demo): add scenario picker for local/demo environments

### DIFF
--- a/src/app/[narmesteLederId]/layout.tsx
+++ b/src/app/[narmesteLederId]/layout.tsx
@@ -3,7 +3,11 @@ import Script from "next/script";
 import "@navikt/dinesykmeldte-sidemeny/dist/dinesykmeldte-sidemeny.css";
 import "@navikt/lumi-survey/styles.css";
 import { Theme } from "@navikt/ds-react";
+import { Suspense } from "react";
 import "@/app/globals.css";
+import { AG_SCENARIO_OPTIONS } from "@/common/demoScenario";
+import { DemoScenarioPicker } from "@/components/DemoScenarioPicker/DemoScenarioPicker";
+import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import { fetchOppfolgingsplanOversiktForAG } from "@/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt";
 import { ArbeidsgiverPageContainer } from "@/ui/layout/ArbeidsgiverPageContainer";
 import { fetchDecoratorForAG } from "@/ui/layout/fetchDecoratorHelpers";
@@ -19,10 +23,10 @@ export default async function RootLayoutForAG({
 }: LayoutProps<"/[narmesteLederId]">) {
   const { narmesteLederId } = await params;
 
-  // This fetch is also done in server components for the oversikt page, so when
-  // visiting the oversikt page first, all these fetch calls made from different
-  // server components (this component included) will be deduplicated by
-  // Next.js.
+  // This fetch always uses the default scenario (no scenario param) because the
+  // layout only needs employee metadata (name, fnr) for the decorator and page
+  // container — not the actual plan data. Plan-specific scenario selection
+  // happens in the page-level server components.
   const oversiktResult =
     await fetchOppfolgingsplanOversiktForAG(narmesteLederId);
 
@@ -54,6 +58,12 @@ export default async function RootLayoutForAG({
         <Decorator.Footer />
 
         <Decorator.Scripts loader={Script} />
+
+        {isLocalOrDemo && (
+          <Suspense>
+            <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />
+          </Suspense>
+        )}
       </body>
     </html>
   );

--- a/src/app/[narmesteLederId]/page.tsx
+++ b/src/app/[narmesteLederId]/page.tsx
@@ -7,6 +7,7 @@ import {
   InfoCardTitle,
 } from "@navikt/ds-react/InfoCard";
 import { Suspense } from "react";
+import { DEMO_SCENARIO_PARAM, parseDemoScenario } from "@/common/demoScenario";
 import TextContentBox from "@/components/layout/TextContentBox";
 import { AnsattIkkeSykmeldtAlert } from "@/components/OversiktSide/AnsattIkkeSykmeldtAlert.tsx";
 import OversiktSideInformasjon from "@/components/OversiktSide/InformasjonSection/OversiktSideInformasjon";
@@ -14,11 +15,17 @@ import { LenkeTilGamlePlanenAG } from "@/components/OversiktSide/LenkeTilGamlePl
 import NyPlanButtonHvisTomListe from "@/components/OversiktSide/PlanListe/NyPlanButtonHvisTomListe";
 import PlanListeForArbeidsgiver from "@/components/OversiktSide/PlanListe/PlanListeForArbeidsgiver";
 import PlanListeSkeleton from "@/components/OversiktSide/PlanListe/PlanListeSkeleton";
+import { isLocalOrDemo } from "@/env-variables/envHelpers";
 
 export default async function OversiktPageForAG({
   params,
+  searchParams,
 }: PageProps<"/[narmesteLederId]">) {
   const { narmesteLederId } = await params;
+  const resolvedSearchParams = await searchParams;
+  const scenario = isLocalOrDemo
+    ? parseDemoScenario(resolvedSearchParams[DEMO_SCENARIO_PARAM])
+    : undefined;
 
   return (
     <>
@@ -45,9 +52,18 @@ export default async function OversiktPageForAG({
       </TextContentBox>
 
       <Suspense fallback={<PlanListeSkeleton />}>
-        <AnsattIkkeSykmeldtAlert narmesteLederId={narmesteLederId} />
-        <NyPlanButtonHvisTomListe narmesteLederId={narmesteLederId} />
-        <PlanListeForArbeidsgiver narmesteLederId={narmesteLederId} />
+        <AnsattIkkeSykmeldtAlert
+          narmesteLederId={narmesteLederId}
+          scenario={scenario}
+        />
+        <NyPlanButtonHvisTomListe
+          narmesteLederId={narmesteLederId}
+          scenario={scenario}
+        />
+        <PlanListeForArbeidsgiver
+          narmesteLederId={narmesteLederId}
+          scenario={scenario}
+        />
       </Suspense>
 
       <OversiktSideInformasjon />

--- a/src/app/sykmeldt/layout.tsx
+++ b/src/app/sykmeldt/layout.tsx
@@ -2,8 +2,12 @@ import { Theme } from "@navikt/ds-react";
 import type { Metadata } from "next";
 import Script from "next/script";
 import type { ReactNode } from "react";
+import { Suspense } from "react";
 import "@navikt/lumi-survey/styles.css";
 import "@/app/globals.css";
+import { SM_SCENARIO_OPTIONS } from "@/common/demoScenario";
+import { DemoScenarioPicker } from "@/components/DemoScenarioPicker/DemoScenarioPicker";
+import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import { Instrumentation } from "@/instrumentation/Instrumentation";
 import { fetchDecoratorForSM } from "@/ui/layout/fetchDecoratorHelpers";
 import { MainContent } from "@/ui/layout/MainContent";
@@ -43,6 +47,12 @@ export default async function RootLayoutForSM({
         <Decorator.Footer />
 
         <Decorator.Scripts loader={Script} />
+
+        {isLocalOrDemo && (
+          <Suspense>
+            <DemoScenarioPicker scenarios={SM_SCENARIO_OPTIONS} />
+          </Suspense>
+        )}
       </body>
     </html>
   );

--- a/src/app/sykmeldt/page.tsx
+++ b/src/app/sykmeldt/page.tsx
@@ -7,11 +7,20 @@ import {
   InfoCardTitle,
 } from "@navikt/ds-react/InfoCard";
 import { Suspense } from "react";
+import { DEMO_SCENARIO_PARAM, parseDemoScenario } from "@/common/demoScenario";
 import TextContentBox from "@/components/layout/TextContentBox.tsx";
 import PlanListeForSykmeldt from "@/components/OversiktSide/PlanListe/PlanListeForSykmeldt.tsx";
 import PlanListeSkeleton from "@/components/OversiktSide/PlanListe/PlanListeSkeleton.tsx";
+import { isLocalOrDemo } from "@/env-variables/envHelpers";
 
-export default async function OversiktPageForSM() {
+export default async function OversiktPageForSM({
+  searchParams,
+}: PageProps<"/sykmeldt">) {
+  const resolvedSearchParams = await searchParams;
+  const scenario = isLocalOrDemo
+    ? parseDemoScenario(resolvedSearchParams[DEMO_SCENARIO_PARAM])
+    : undefined;
+
   return (
     <>
       <Heading level="2" size="xlarge" spacing>
@@ -43,7 +52,7 @@ export default async function OversiktPageForSM() {
       </TextContentBox>
 
       <Suspense fallback={<PlanListeSkeleton />}>
-        <PlanListeForSykmeldt />
+        <PlanListeForSykmeldt scenario={scenario} />
       </Suspense>
     </>
   );

--- a/src/common/__tests__/demoScenario.test.ts
+++ b/src/common/__tests__/demoScenario.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_DEMO_SCENARIO,
+  parseDemoScenario,
+} from "@/common/demoScenario";
+
+describe("parseDemoScenario", () => {
+  it("returnerer riktig scenario for gyldig input 'tom'", () => {
+    expect(parseDemoScenario("tom")).toBe("tom");
+  });
+
+  it("returnerer riktig scenario for gyldig input 'aktiv-og-tidligere'", () => {
+    expect(parseDemoScenario("aktiv-og-tidligere")).toBe("aktiv-og-tidligere");
+  });
+
+  it("returnerer riktig scenario for gyldig input 'aktiv-utkast-og-tidligere'", () => {
+    expect(parseDemoScenario("aktiv-utkast-og-tidligere")).toBe(
+      "aktiv-utkast-og-tidligere",
+    );
+  });
+
+  it("returnerer DEFAULT_DEMO_SCENARIO for ugyldig string", () => {
+    expect(parseDemoScenario("ugyldig-verdi")).toBe(DEFAULT_DEMO_SCENARIO);
+  });
+
+  it("returnerer DEFAULT_DEMO_SCENARIO for undefined", () => {
+    expect(parseDemoScenario(undefined)).toBe(DEFAULT_DEMO_SCENARIO);
+  });
+
+  it("returnerer DEFAULT_DEMO_SCENARIO for array input", () => {
+    expect(parseDemoScenario(["tom", "aktiv-og-tidligere"])).toBe(
+      DEFAULT_DEMO_SCENARIO,
+    );
+  });
+});

--- a/src/common/demoScenario.ts
+++ b/src/common/demoScenario.ts
@@ -1,0 +1,45 @@
+export const DEMO_SCENARIO_PARAM = "scenario";
+
+export type DemoScenario =
+  | "tom"
+  | "aktiv-og-tidligere"
+  | "aktiv-utkast-og-tidligere";
+
+export const DEFAULT_DEMO_SCENARIO: DemoScenario = "aktiv-og-tidligere";
+
+const VALID_SCENARIOS: DemoScenario[] = [
+  "tom",
+  "aktiv-og-tidligere",
+  "aktiv-utkast-og-tidligere",
+];
+
+export function parseDemoScenario(
+  value: string | string[] | undefined,
+): DemoScenario {
+  if (
+    typeof value === "string" &&
+    VALID_SCENARIOS.includes(value as DemoScenario)
+  ) {
+    return value as DemoScenario;
+  }
+  return DEFAULT_DEMO_SCENARIO;
+}
+
+export type DemoScenarioOption = {
+  value: DemoScenario;
+  label: string;
+};
+
+export const AG_SCENARIO_OPTIONS: DemoScenarioOption[] = [
+  { value: "tom", label: "Tom" },
+  { value: "aktiv-og-tidligere", label: "Aktiv plan + tidligere planer" },
+  {
+    value: "aktiv-utkast-og-tidligere",
+    label: "Aktiv plan, utkast + tidligere planer",
+  },
+];
+
+export const SM_SCENARIO_OPTIONS: DemoScenarioOption[] = [
+  { value: "tom", label: "Tom" },
+  { value: "aktiv-og-tidligere", label: "Aktiv plan + tidligere planer" },
+];

--- a/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
+++ b/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { TestFlaskIcon } from "@navikt/aksel-icons";
+import { Button, Modal, Radio, RadioGroup } from "@navikt/ds-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useRef, useState } from "react";
+import {
+  DEFAULT_DEMO_SCENARIO,
+  DEMO_SCENARIO_PARAM,
+  type DemoScenario,
+  type DemoScenarioOption,
+  parseDemoScenario,
+} from "@/common/demoScenario";
+
+export function DemoScenarioPicker({
+  scenarios,
+}: {
+  scenarios: DemoScenarioOption[];
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+
+  const currentScenario = parseDemoScenario(
+    searchParams.get(DEMO_SCENARIO_PARAM) ?? undefined,
+  );
+  const [selected, setSelected] = useState<DemoScenario>(currentScenario);
+
+  function handleOpen() {
+    setSelected(currentScenario);
+    setOpen(true);
+  }
+
+  function handleApply() {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set(DEMO_SCENARIO_PARAM, selected);
+    router.push(`${pathname}?${params.toString()}`);
+    setOpen(false);
+  }
+
+  return (
+    <>
+      <div
+        style={{
+          position: "fixed",
+          bottom: "1.5rem",
+          right: "1.5rem",
+          zIndex: 9999,
+        }}
+      >
+        <Button
+          ref={buttonRef}
+          variant="primary"
+          size="medium"
+          icon={<TestFlaskIcon aria-hidden />}
+          onClick={handleOpen}
+          aria-label="Velg demo-scenario"
+        >
+          Demo
+        </Button>
+      </div>
+
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        header={{ heading: "Demo-scenario", closeButton: true }}
+        width="small"
+      >
+        <Modal.Body>
+          <RadioGroup
+            legend="Velg scenario"
+            value={selected ?? DEFAULT_DEMO_SCENARIO}
+            onChange={(value) => setSelected(value as DemoScenario)}
+          >
+            {scenarios.map(({ value, label }) => (
+              <Radio key={value} value={value}>
+                {label}
+              </Radio>
+            ))}
+          </RadioGroup>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={handleApply}>Bruk scenario</Button>
+          <Button variant="tertiary" onClick={() => setOpen(false)}>
+            Avbryt
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/OversiktSide/AnsattIkkeSykmeldtAlert.tsx
+++ b/src/components/OversiktSide/AnsattIkkeSykmeldtAlert.tsx
@@ -1,13 +1,18 @@
 import { Alert, BodyShort, Box, Heading } from "@navikt/ds-react";
+import type { DemoScenario } from "@/common/demoScenario";
 import { fetchOppfolgingsplanOversiktForAG } from "@/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt.ts";
 
 export async function AnsattIkkeSykmeldtAlert({
   narmesteLederId,
+  scenario,
 }: {
   narmesteLederId: string;
+  scenario?: DemoScenario;
 }) {
-  const oversiktResult =
-    await fetchOppfolgingsplanOversiktForAG(narmesteLederId);
+  const oversiktResult = await fetchOppfolgingsplanOversiktForAG(
+    narmesteLederId,
+    scenario,
+  );
 
   if (oversiktResult.error) return null;
 

--- a/src/components/OversiktSide/PlanListe/NyPlanButtonHvisTomListe.tsx
+++ b/src/components/OversiktSide/PlanListe/NyPlanButtonHvisTomListe.tsx
@@ -1,13 +1,18 @@
+import type { DemoScenario } from "@/common/demoScenario";
 import { fetchOppfolgingsplanOversiktForAG } from "@/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt";
 import { LagNyOppfolgingsplanButton } from "./NyPlanButton";
 
 export default async function NyPlanButtonHvisTomListe({
   narmesteLederId,
+  scenario,
 }: {
   narmesteLederId: string;
+  scenario?: DemoScenario;
 }) {
-  const oversiktResult =
-    await fetchOppfolgingsplanOversiktForAG(narmesteLederId);
+  const oversiktResult = await fetchOppfolgingsplanOversiktForAG(
+    narmesteLederId,
+    scenario,
+  );
 
   if (oversiktResult.error) return null;
 

--- a/src/components/OversiktSide/PlanListe/PlanListeForArbeidsgiver.tsx
+++ b/src/components/OversiktSide/PlanListe/PlanListeForArbeidsgiver.tsx
@@ -1,4 +1,5 @@
 import { BodyShort, VStack } from "@navikt/ds-react";
+import type { DemoScenario } from "@/common/demoScenario";
 import {
   getAGAktivPlanHref,
   getAGTidligerePlanHref,
@@ -13,13 +14,17 @@ import { SlettUtkastButtonAndModal } from "./SlettUtkast/SlettUtkastButtonAndMod
 
 interface Props {
   narmesteLederId: string;
+  scenario?: DemoScenario;
 }
 
 export default async function PlanListeForArbeidsgiver({
   narmesteLederId,
+  scenario,
 }: Props) {
-  const oversiktResult =
-    await fetchOppfolgingsplanOversiktForAG(narmesteLederId);
+  const oversiktResult = await fetchOppfolgingsplanOversiktForAG(
+    narmesteLederId,
+    scenario,
+  );
 
   if (oversiktResult.error) {
     return (

--- a/src/components/OversiktSide/PlanListe/PlanListeForSykmeldt.tsx
+++ b/src/components/OversiktSide/PlanListe/PlanListeForSykmeldt.tsx
@@ -1,4 +1,5 @@
 import { BodyShort, VStack } from "@navikt/ds-react";
+import type { DemoScenario } from "@/common/demoScenario";
 import {
   getSMAktivPlanHref,
   getSMTidligerePlanHref,
@@ -9,9 +10,13 @@ import AktivPlanLinkCard from "./PlanLinkCard/AktivPlanLinkCard";
 import TidligerePlanLinkCard from "./PlanLinkCard/TidligerePlanLinkCard";
 import PlanListeDel from "./PlanListeDel";
 
-export default async function PlanListeForSykmeldt() {
+export default async function PlanListeForSykmeldt({
+  scenario,
+}: {
+  scenario?: DemoScenario;
+}) {
   const { aktiveOppfolgingsplaner, tidligerePlaner } =
-    await fetchOppfolgingsplanOversiktForSM();
+    await fetchOppfolgingsplanOversiktForSM(scenario);
 
   const harAktivePlaner = aktiveOppfolgingsplaner.length > 0;
   const harTidligerePlaner = tidligerePlaner.length > 0;

--- a/src/components/OversiktSide/PlanListe/__tests__/NyPlanButtonHvisTomListe.test.tsx
+++ b/src/components/OversiktSide/PlanListe/__tests__/NyPlanButtonHvisTomListe.test.tsx
@@ -13,7 +13,9 @@ import { renderAsync } from "@/test/test-utils";
 import NyPlanButtonHvisTomListe from "../NyPlanButtonHvisTomListe";
 
 vi.mock("next/navigation", async () => {
-  const { mockNextNavigation } = await import("@/test/mocks/nextNavigationMock");
+  const { mockNextNavigation } = await import(
+    "@/test/mocks/nextNavigationMock"
+  );
 
   return mockNextNavigation();
 });
@@ -39,7 +41,7 @@ describe("NyPlanButtonHvisTomListe", () => {
       NyPlanButtonHvisTomListe({ narmesteLederId: "test-123" }),
     );
 
-    expect(mockFetch).toHaveBeenCalledWith("test-123");
+    expect(mockFetch).toHaveBeenCalledWith("test-123", undefined);
   });
 
   test("shows button when list is empty and user has edit access", async () => {

--- a/src/components/OversiktSide/PlanListe/__tests__/PlanListeForArbeidsgiver.test.tsx
+++ b/src/components/OversiktSide/PlanListe/__tests__/PlanListeForArbeidsgiver.test.tsx
@@ -13,7 +13,9 @@ import {
 import { renderAsync } from "@/test/test-utils";
 
 vi.mock("next/navigation", async () => {
-  const { mockNextNavigation } = await import("@/test/mocks/nextNavigationMock");
+  const { mockNextNavigation } = await import(
+    "@/test/mocks/nextNavigationMock"
+  );
 
   return mockNextNavigation();
 });
@@ -39,7 +41,7 @@ describe("PlanListeForArbeidsgiver", () => {
       PlanListeForArbeidsgiver({ narmesteLederId: "test-123" }),
     );
 
-    expect(mockFetch).toHaveBeenCalledWith("test-123");
+    expect(mockFetch).toHaveBeenCalledWith("test-123", undefined);
   });
 
   test("displays error alert when fetch fails", async () => {

--- a/src/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt.ts
+++ b/src/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt.ts
@@ -1,4 +1,8 @@
 import { getEndpointOversiktForAG } from "@/common/backend-endpoints";
+import {
+  DEFAULT_DEMO_SCENARIO,
+  type DemoScenario,
+} from "@/common/demoScenario";
 import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import {
   type OppfolgingsplanerOversiktForAG,
@@ -8,18 +12,38 @@ import { getRedirectAfterLoginUrlForAG } from "@/server/auth/redirectToLogin";
 import { TokenXTargetApi } from "@/server/auth/tokenXExchange";
 import type { FetchGetResult } from "@/server/tokenXFetch/FetchResult";
 import { tokenXFetchGetWithResult } from "@/server/tokenXFetch/tokenXFetchGetWithResult";
-import { mockOversiktDataMedPlanerForAG } from "../mockData/mockOversiktData";
+import {
+  mockOversiktDataMedPlanerForAG,
+  mockOversiktDataTom,
+} from "../mockData/mockOversiktData";
+import { mockOversiktDataAktivOgTidligere } from "../mockData/mockOversiktDataVariants";
 import { simulateBackendDelay } from "../mockData/simulateBackendDelay";
+
+function getMockDataForScenario(scenario: DemoScenario) {
+  switch (scenario) {
+    case "tom":
+      return mockOversiktDataTom;
+    case "aktiv-og-tidligere":
+      return mockOversiktDataAktivOgTidligere;
+    case "aktiv-utkast-og-tidligere":
+      return mockOversiktDataMedPlanerForAG;
+    default: {
+      const _exhaustive: never = scenario;
+      throw new Error(`Ukjent demo-scenario: ${_exhaustive}`);
+    }
+  }
+}
 
 export async function fetchOppfolgingsplanOversiktForAG(
   narmesteLederId: string,
+  scenario: DemoScenario = DEFAULT_DEMO_SCENARIO,
 ): Promise<FetchGetResult<OppfolgingsplanerOversiktForAG>> {
   if (isLocalOrDemo) {
     await simulateBackendDelay();
 
     return {
       error: null,
-      data: mockOversiktDataMedPlanerForAG,
+      data: getMockDataForScenario(scenario),
     };
   }
 

--- a/src/server/fetchData/mockData/mockOversiktData.ts
+++ b/src/server/fetchData/mockData/mockOversiktData.ts
@@ -29,3 +29,13 @@ export const mockOversiktDataMedPlanerForSM: OppfolgingsplanerOversiktForSM = {
   aktiveOppfolgingsplaner: [mockAktivPlanData],
   tidligerePlaner: mockTidligerePlanerData,
 };
+
+export const mockOversiktDataTomForSM: OppfolgingsplanerOversiktForSM = {
+  aktiveOppfolgingsplaner: [],
+  tidligerePlaner: [],
+};
+
+export const mockOversiktDataKunAktivForSM: OppfolgingsplanerOversiktForSM = {
+  aktiveOppfolgingsplaner: [mockAktivPlanData],
+  tidligerePlaner: [],
+};

--- a/src/server/fetchData/mockData/mockOversiktDataVariants.ts
+++ b/src/server/fetchData/mockData/mockOversiktDataVariants.ts
@@ -71,3 +71,14 @@ export const mockOversiktDataEmptyNoAccess: OppfolgingsplanerOversiktForAG = {
     tidligerePlaner: [],
   },
 };
+
+// Active plan + previous plans, no draft
+export const mockOversiktDataAktivOgTidligere: OppfolgingsplanerOversiktForAG =
+  {
+    ...mockCommonAGResponseFields,
+    oversikt: {
+      utkast: null,
+      aktivPlan: mockAktivPlanData,
+      tidligerePlaner: mockTidligerePlanerData,
+    },
+  };

--- a/src/server/fetchData/sykmeldt/fetchOppfolgingsplanOversiktForSM.ts
+++ b/src/server/fetchData/sykmeldt/fetchOppfolgingsplanOversiktForSM.ts
@@ -1,3 +1,7 @@
+import {
+  DEFAULT_DEMO_SCENARIO,
+  type DemoScenario,
+} from "@/common/demoScenario";
 import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import { getServerEnv } from "@/env-variables/serverEnv";
 import {
@@ -7,13 +11,32 @@ import {
 import { getRedirectAfterLoginUrlForSM } from "@/server/auth/redirectToLogin";
 import { TokenXTargetApi } from "@/server/auth/tokenXExchange";
 import { tokenXFetchGet } from "@/server/tokenXFetch/tokenXFetchGet";
-import { mockOversiktDataMedPlanerForSM } from "../mockData/mockOversiktData";
+import {
+  mockOversiktDataMedPlanerForSM,
+  mockOversiktDataTomForSM,
+} from "../mockData/mockOversiktData";
 import { simulateBackendDelay } from "../mockData/simulateBackendDelay";
 
-export async function fetchOppfolgingsplanOversiktForSM(): Promise<OppfolgingsplanerOversiktForSM> {
+function getMockDataForScenarioSM(scenario: DemoScenario) {
+  switch (scenario) {
+    case "tom":
+      return mockOversiktDataTomForSM;
+    case "aktiv-og-tidligere":
+    case "aktiv-utkast-og-tidligere":
+      return mockOversiktDataMedPlanerForSM;
+    default: {
+      const _exhaustive: never = scenario;
+      throw new Error(`Ukjent demo-scenario: ${_exhaustive}`);
+    }
+  }
+}
+
+export async function fetchOppfolgingsplanOversiktForSM(
+  scenario: DemoScenario = DEFAULT_DEMO_SCENARIO,
+): Promise<OppfolgingsplanerOversiktForSM> {
   if (isLocalOrDemo) {
     await simulateBackendDelay();
-    return mockOversiktDataMedPlanerForSM;
+    return getMockDataForScenarioSM(scenario);
   }
 
   return await tokenXFetchGet({


### PR DESCRIPTION
## Beskrivelse

Legger til en demo-scenarioplukker som lar utviklere bytte mellom ulike mock-data-scenarioer i lokal- og demo-miljøer. Scenarioene styrer hvilken oversiktdata som vises: tom, aktiv+tidligere planer, eller aktiv+utkast+tidligere.

## Endringer

- `src/common/demoScenario.ts`: Scenariotype, konstanter og parser (flyttet fra `@/server/`)
- `src/components/DemoScenarioPicker/DemoScenarioPicker.tsx`: Flytende knapp + modal for scenariovalg
- `src/app/[narmesteLederId]/layout.tsx` + `src/app/sykmeldt/layout.tsx`: Rendrer picker i Suspense når `isLocalOrDemo`
- `src/app/[narmesteLederId]/page.tsx` + `src/app/sykmeldt/page.tsx`: Parser scenario fra searchParams
- `src/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt.ts` + SM-variant: Scenario-basert mock-data-valg med exhaustive switch
- `src/components/OversiktSide/`: Komponenter aksepterer valgfri `scenario`-prop
- `src/server/fetchData/mockData/`: Nye mock-data-varianter for testing og demo
- `src/common/__tests__/demoScenario.test.ts`: 6 tester for parser

### Review-funn adressert
- `isLocalOrDemo` bruker `.env.development` i stedet for `NODE_ENV`-sjekk
- Pickeren tar `scenarios`-prop — SM viser kun scenarioer med effekt
- Exhaustive `default: never` i scenario-switches

## Issue

Ingen tilknyttet issue.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)