### PR TITLE
feat(demo): add scenario picker with cookie-based mock data selection

### DIFF
--- a/src/app/[narmesteLederId]/layout.tsx
+++ b/src/app/[narmesteLederId]/layout.tsx
@@ -51,6 +51,11 @@ export default async function RootLayoutForAG({
           >
             <Theme>
               <main className="max-w-[730px]">{children}</main>
+              {isLocalOrDemo && (
+                <Suspense>
+                  <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />
+                </Suspense>
+              )}
             </Theme>
           </ArbeidsgiverPageContainer>
         </Instrumentation>
@@ -58,12 +63,6 @@ export default async function RootLayoutForAG({
         <Decorator.Footer />
 
         <Decorator.Scripts loader={Script} />
-
-        {isLocalOrDemo && (
-          <Suspense>
-            <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />
-          </Suspense>
-        )}
       </body>
     </html>
   );

--- a/src/app/[narmesteLederId]/layout.tsx
+++ b/src/app/[narmesteLederId]/layout.tsx
@@ -52,7 +52,7 @@ export default async function RootLayoutForAG({
             <Theme>
               <main className="max-w-[730px]">{children}</main>
               {isLocalOrDemo && (
-                <Suspense>
+                <Suspense fallback={null}>
                   <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />
                 </Suspense>
               )}

--- a/src/app/[narmesteLederId]/layout.tsx
+++ b/src/app/[narmesteLederId]/layout.tsx
@@ -3,7 +3,11 @@ import Script from "next/script";
 import "@navikt/dinesykmeldte-sidemeny/dist/dinesykmeldte-sidemeny.css";
 import "@navikt/lumi-survey/styles.css";
 import { Theme } from "@navikt/ds-react";
+import { Suspense } from "react";
 import "@/app/globals.css";
+import { AG_SCENARIO_OPTIONS } from "@/common/demoScenario";
+import { DemoScenarioPicker } from "@/components/DemoScenarioPicker/DemoScenarioPicker";
+import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import { fetchOppfolgingsplanOversiktForAG } from "@/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt";
 import { ArbeidsgiverPageContainer } from "@/ui/layout/ArbeidsgiverPageContainer";
 import { fetchDecoratorForAG } from "@/ui/layout/fetchDecoratorHelpers";
@@ -54,6 +58,12 @@ export default async function RootLayoutForAG({
         <Decorator.Footer />
 
         <Decorator.Scripts loader={Script} />
+
+        {isLocalOrDemo && (
+          <Suspense>
+            <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />
+          </Suspense>
+        )}
       </body>
     </html>
   );

--- a/src/app/sykmeldt/layout.tsx
+++ b/src/app/sykmeldt/layout.tsx
@@ -2,8 +2,12 @@ import { Theme } from "@navikt/ds-react";
 import type { Metadata } from "next";
 import Script from "next/script";
 import type { ReactNode } from "react";
+import { Suspense } from "react";
 import "@navikt/lumi-survey/styles.css";
 import "@/app/globals.css";
+import { SM_SCENARIO_OPTIONS } from "@/common/demoScenario";
+import { DemoScenarioPicker } from "@/components/DemoScenarioPicker/DemoScenarioPicker";
+import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import { Instrumentation } from "@/instrumentation/Instrumentation";
 import { fetchDecoratorForSM } from "@/ui/layout/fetchDecoratorHelpers";
 import { MainContent } from "@/ui/layout/MainContent";
@@ -43,6 +47,12 @@ export default async function RootLayoutForSM({
         <Decorator.Footer />
 
         <Decorator.Scripts loader={Script} />
+
+        {isLocalOrDemo && (
+          <Suspense>
+            <DemoScenarioPicker scenarios={SM_SCENARIO_OPTIONS} />
+          </Suspense>
+        )}
       </body>
     </html>
   );

--- a/src/app/sykmeldt/layout.tsx
+++ b/src/app/sykmeldt/layout.tsx
@@ -1,8 +1,7 @@
 import { Theme } from "@navikt/ds-react";
 import type { Metadata } from "next";
 import Script from "next/script";
-import type { ReactNode } from "react";
-import { Suspense } from "react";
+import { type ReactNode, Suspense } from "react";
 import "@navikt/lumi-survey/styles.css";
 import "@/app/globals.css";
 import { SM_SCENARIO_OPTIONS } from "@/common/demoScenario";

--- a/src/app/sykmeldt/layout.tsx
+++ b/src/app/sykmeldt/layout.tsx
@@ -42,7 +42,7 @@ export default async function RootLayoutForSM({
             <BreadcrumbsUpdaterForSM />
             <MainContent>{children}</MainContent>
             {isLocalOrDemo && (
-              <Suspense>
+              <Suspense fallback={null}>
                 <DemoScenarioPicker scenarios={SM_SCENARIO_OPTIONS} />
               </Suspense>
             )}

--- a/src/app/sykmeldt/layout.tsx
+++ b/src/app/sykmeldt/layout.tsx
@@ -41,18 +41,17 @@ export default async function RootLayoutForSM({
           <Theme>
             <BreadcrumbsUpdaterForSM />
             <MainContent>{children}</MainContent>
+            {isLocalOrDemo && (
+              <Suspense>
+                <DemoScenarioPicker scenarios={SM_SCENARIO_OPTIONS} />
+              </Suspense>
+            )}
           </Theme>
         </Instrumentation>
 
         <Decorator.Footer />
 
         <Decorator.Scripts loader={Script} />
-
-        {isLocalOrDemo && (
-          <Suspense>
-            <DemoScenarioPicker scenarios={SM_SCENARIO_OPTIONS} />
-          </Suspense>
-        )}
       </body>
     </html>
   );

--- a/src/app/sykmeldt/page.tsx
+++ b/src/app/sykmeldt/page.tsx
@@ -11,7 +11,7 @@ import TextContentBox from "@/components/layout/TextContentBox.tsx";
 import PlanListeForSykmeldt from "@/components/OversiktSide/PlanListe/PlanListeForSykmeldt.tsx";
 import PlanListeSkeleton from "@/components/OversiktSide/PlanListe/PlanListeSkeleton.tsx";
 
-export default async function OversiktPageForSM() {
+export default async function OversiktPageForSM(_: PageProps<"/sykmeldt">) {
   return (
     <>
       <Heading level="2" size="xlarge" spacing>

--- a/src/common/__tests__/demoScenario.test.ts
+++ b/src/common/__tests__/demoScenario.test.ts
@@ -5,29 +5,29 @@ import {
 } from "@/common/demoScenario";
 
 describe("parseDemoScenario", () => {
-  it("returnerer riktig scenario for gyldig input 'tom'", () => {
+  it("returns correct scenario for valid input 'tom'", () => {
     expect(parseDemoScenario("tom")).toBe("tom");
   });
 
-  it("returnerer riktig scenario for gyldig input 'aktiv-og-tidligere'", () => {
+  it("returns correct scenario for valid input 'aktiv-og-tidligere'", () => {
     expect(parseDemoScenario("aktiv-og-tidligere")).toBe("aktiv-og-tidligere");
   });
 
-  it("returnerer riktig scenario for gyldig input 'aktiv-utkast-og-tidligere'", () => {
+  it("returns correct scenario for valid input 'aktiv-utkast-og-tidligere'", () => {
     expect(parseDemoScenario("aktiv-utkast-og-tidligere")).toBe(
       "aktiv-utkast-og-tidligere",
     );
   });
 
-  it("returnerer DEFAULT_DEMO_SCENARIO for ugyldig string", () => {
+  it("returns DEFAULT_DEMO_SCENARIO for invalid string", () => {
     expect(parseDemoScenario("ugyldig-verdi")).toBe(DEFAULT_DEMO_SCENARIO);
   });
 
-  it("returnerer DEFAULT_DEMO_SCENARIO for undefined", () => {
+  it("returns DEFAULT_DEMO_SCENARIO for undefined", () => {
     expect(parseDemoScenario(undefined)).toBe(DEFAULT_DEMO_SCENARIO);
   });
 
-  it("returnerer DEFAULT_DEMO_SCENARIO for array input", () => {
+  it("returns DEFAULT_DEMO_SCENARIO for array input", () => {
     expect(parseDemoScenario(["tom", "aktiv-og-tidligere"])).toBe(
       DEFAULT_DEMO_SCENARIO,
     );

--- a/src/common/__tests__/demoScenario.test.ts
+++ b/src/common/__tests__/demoScenario.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_DEMO_SCENARIO,
+  parseDemoScenario,
+} from "@/common/demoScenario";
+
+describe("parseDemoScenario", () => {
+  it("returnerer riktig scenario for gyldig input 'tom'", () => {
+    expect(parseDemoScenario("tom")).toBe("tom");
+  });
+
+  it("returnerer riktig scenario for gyldig input 'aktiv-og-tidligere'", () => {
+    expect(parseDemoScenario("aktiv-og-tidligere")).toBe("aktiv-og-tidligere");
+  });
+
+  it("returnerer riktig scenario for gyldig input 'aktiv-utkast-og-tidligere'", () => {
+    expect(parseDemoScenario("aktiv-utkast-og-tidligere")).toBe(
+      "aktiv-utkast-og-tidligere",
+    );
+  });
+
+  it("returnerer DEFAULT_DEMO_SCENARIO for ugyldig string", () => {
+    expect(parseDemoScenario("ugyldig-verdi")).toBe(DEFAULT_DEMO_SCENARIO);
+  });
+
+  it("returnerer DEFAULT_DEMO_SCENARIO for undefined", () => {
+    expect(parseDemoScenario(undefined)).toBe(DEFAULT_DEMO_SCENARIO);
+  });
+
+  it("returnerer DEFAULT_DEMO_SCENARIO for array input", () => {
+    expect(parseDemoScenario(["tom", "aktiv-og-tidligere"])).toBe(
+      DEFAULT_DEMO_SCENARIO,
+    );
+  });
+});

--- a/src/common/demoScenario.ts
+++ b/src/common/demoScenario.ts
@@ -1,24 +1,21 @@
 export const DEMO_SCENARIO_COOKIE = "demo-scenario";
 
-export type DemoScenario =
-  | "tom"
-  | "aktiv-og-tidligere"
-  | "aktiv-utkast-og-tidligere";
-
-export const DEFAULT_DEMO_SCENARIO: DemoScenario = "aktiv-og-tidligere";
-
-const VALID_SCENARIOS: DemoScenario[] = [
+const VALID_SCENARIOS = [
   "tom",
   "aktiv-og-tidligere",
   "aktiv-utkast-og-tidligere",
-];
+] as const;
+
+export type DemoScenario = (typeof VALID_SCENARIOS)[number];
+
+export const DEFAULT_DEMO_SCENARIO: DemoScenario = "aktiv-og-tidligere";
 
 export function parseDemoScenario(
   value: string | string[] | undefined,
 ): DemoScenario {
   if (
     typeof value === "string" &&
-    VALID_SCENARIOS.includes(value as DemoScenario)
+    (VALID_SCENARIOS as readonly string[]).includes(value)
   ) {
     return value as DemoScenario;
   }

--- a/src/common/demoScenario.ts
+++ b/src/common/demoScenario.ts
@@ -1,0 +1,45 @@
+export const DEMO_SCENARIO_COOKIE = "demo-scenario";
+
+export type DemoScenario =
+  | "tom"
+  | "aktiv-og-tidligere"
+  | "aktiv-utkast-og-tidligere";
+
+export const DEFAULT_DEMO_SCENARIO: DemoScenario = "aktiv-og-tidligere";
+
+const VALID_SCENARIOS: DemoScenario[] = [
+  "tom",
+  "aktiv-og-tidligere",
+  "aktiv-utkast-og-tidligere",
+];
+
+export function parseDemoScenario(
+  value: string | string[] | undefined,
+): DemoScenario {
+  if (
+    typeof value === "string" &&
+    VALID_SCENARIOS.includes(value as DemoScenario)
+  ) {
+    return value as DemoScenario;
+  }
+  return DEFAULT_DEMO_SCENARIO;
+}
+
+export type DemoScenarioOption = {
+  value: DemoScenario;
+  label: string;
+};
+
+export const AG_SCENARIO_OPTIONS: DemoScenarioOption[] = [
+  { value: "tom", label: "Tom" },
+  { value: "aktiv-og-tidligere", label: "Aktiv plan + tidligere planer" },
+  {
+    value: "aktiv-utkast-og-tidligere",
+    label: "Aktiv plan, utkast + tidligere planer",
+  },
+];
+
+export const SM_SCENARIO_OPTIONS: DemoScenarioOption[] = [
+  { value: "tom", label: "Tom" },
+  { value: "aktiv-og-tidligere", label: "Aktiv plan + tidligere planer" },
+];

--- a/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
+++ b/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
@@ -44,7 +44,7 @@ export function DemoScenarioPicker({
   function handleApply() {
     const secure = window.location.protocol === "https:" ? "; Secure" : "";
     // biome-ignore lint/suspicious/noDocumentCookie: task requires document.cookie to support current local/demo flow
-    document.cookie = `${DEMO_SCENARIO_COOKIE}=${selected}; path=/; max-age=86400; SameSite=Lax${secure}`;
+    document.cookie = `${DEMO_SCENARIO_COOKIE}=${selected}; path=/; max-age=0; SameSite=Lax${secure}`;
     router.refresh();
     setOpen(false);
   }
@@ -64,7 +64,6 @@ export function DemoScenarioPicker({
           size="medium"
           icon={<TestFlaskIcon aria-hidden />}
           onClick={handleOpen}
-          aria-label="Velg demo-scenario"
         >
           Demo
         </Button>
@@ -79,7 +78,7 @@ export function DemoScenarioPicker({
         <Modal.Body>
           <RadioGroup
             legend="Velg scenario"
-            value={selected ?? DEFAULT_DEMO_SCENARIO}
+            value={selected}
             onChange={(value) => setSelected(parseDemoScenario(value))}
           >
             {scenarios.map(({ value, label }) => (

--- a/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
+++ b/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { TestFlaskIcon } from "@navikt/aksel-icons";
+import { Box, Button, Modal, Radio, RadioGroup } from "@navikt/ds-react";
+import { useRouter } from "next/navigation";
+import { useRef, useState } from "react";
+import {
+  DEFAULT_DEMO_SCENARIO,
+  DEMO_SCENARIO_COOKIE,
+  type DemoScenario,
+  type DemoScenarioOption,
+  parseDemoScenario,
+} from "@/common/demoScenario";
+
+export function DemoScenarioPicker({
+  scenarios,
+}: {
+  scenarios: DemoScenarioOption[];
+}) {
+  const router = useRouter();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<DemoScenario>(DEFAULT_DEMO_SCENARIO);
+
+  function handleOpen() {
+    const cookieValue = document.cookie
+      .split("; ")
+      .find((cookie) => cookie.startsWith(`${DEMO_SCENARIO_COOKIE}=`))
+      ?.split("=")
+      .slice(1)
+      .join("=");
+    const parsed = parseDemoScenario(cookieValue);
+    const currentScenario = scenarios.some(
+      (scenario) => scenario.value === parsed,
+    )
+      ? parsed
+      : (scenarios[0]?.value ?? DEFAULT_DEMO_SCENARIO);
+
+    setSelected(currentScenario);
+    setOpen(true);
+  }
+
+  function handleApply() {
+    // biome-ignore lint/suspicious/noDocumentCookie: task requires document.cookie to support current local/demo flow
+    document.cookie = `${DEMO_SCENARIO_COOKIE}=${selected}; path=/; max-age=86400; SameSite=Lax`;
+    router.refresh();
+    setOpen(false);
+  }
+
+  return (
+    <>
+      <Box
+        position="fixed"
+        style={{
+          bottom: "var(--a-spacing-6)",
+          right: "var(--a-spacing-6)",
+          zIndex: 100,
+        }}
+      >
+        <Button
+          ref={buttonRef}
+          variant="primary"
+          size="medium"
+          icon={<TestFlaskIcon aria-hidden />}
+          onClick={handleOpen}
+          aria-label="Velg demo-scenario"
+        >
+          Demo
+        </Button>
+      </Box>
+
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        header={{ heading: "Demo-scenario", closeButton: true }}
+        width="small"
+      >
+        <Modal.Body>
+          <RadioGroup
+            legend="Velg scenario"
+            value={selected ?? DEFAULT_DEMO_SCENARIO}
+            onChange={(value) => setSelected(parseDemoScenario(value))}
+          >
+            {scenarios.map(({ value, label }) => (
+              <Radio key={value} value={value}>
+                {label}
+              </Radio>
+            ))}
+          </RadioGroup>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={handleApply}>Bruk scenario</Button>
+          <Button variant="tertiary" onClick={() => setOpen(false)}>
+            Avbryt
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
+++ b/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
@@ -3,7 +3,7 @@
 import { TestFlaskIcon } from "@navikt/aksel-icons";
 import { Box, Button, Modal, Radio, RadioGroup } from "@navikt/ds-react";
 import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import {
   DEFAULT_DEMO_SCENARIO,
   DEMO_SCENARIO_COOKIE,
@@ -18,7 +18,6 @@ export function DemoScenarioPicker({
   scenarios: DemoScenarioOption[];
 }) {
   const router = useRouter();
-  const buttonRef = useRef<HTMLButtonElement>(null);
   const [open, setOpen] = useState(false);
   const [selected, setSelected] = useState<DemoScenario>(DEFAULT_DEMO_SCENARIO);
 
@@ -61,7 +60,6 @@ export function DemoScenarioPicker({
         }}
       >
         <Button
-          ref={buttonRef}
           variant="primary"
           size="medium"
           icon={<TestFlaskIcon aria-hidden />}

--- a/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
+++ b/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
@@ -23,7 +23,8 @@ export function DemoScenarioPicker({
 
   function handleOpen() {
     const cookieValue = document.cookie
-      .split("; ")
+      .split(";")
+      .map((c) => c.trim())
       .find((cookie) => cookie.startsWith(`${DEMO_SCENARIO_COOKIE}=`))
       ?.split("=")
       .slice(1)
@@ -44,7 +45,7 @@ export function DemoScenarioPicker({
   function handleApply() {
     const secure = window.location.protocol === "https:" ? "; Secure" : "";
     // biome-ignore lint/suspicious/noDocumentCookie: task requires document.cookie to support current local/demo flow
-    document.cookie = `${DEMO_SCENARIO_COOKIE}=${selected}; path=/; max-age=0; SameSite=Lax${secure}`;
+    document.cookie = `${DEMO_SCENARIO_COOKIE}=${selected}; path=/; SameSite=Lax${secure}`;
     router.refresh();
     setOpen(false);
   }

--- a/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
+++ b/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
@@ -34,15 +34,18 @@ export function DemoScenarioPicker({
       (scenario) => scenario.value === parsed,
     )
       ? parsed
-      : (scenarios[0]?.value ?? DEFAULT_DEMO_SCENARIO);
+      : scenarios.some((s) => s.value === DEFAULT_DEMO_SCENARIO)
+        ? DEFAULT_DEMO_SCENARIO
+        : (scenarios[0]?.value ?? DEFAULT_DEMO_SCENARIO);
 
     setSelected(currentScenario);
     setOpen(true);
   }
 
   function handleApply() {
+    const secure = window.location.protocol === "https:" ? "; Secure" : "";
     // biome-ignore lint/suspicious/noDocumentCookie: task requires document.cookie to support current local/demo flow
-    document.cookie = `${DEMO_SCENARIO_COOKIE}=${selected}; path=/; max-age=86400; SameSite=Lax`;
+    document.cookie = `${DEMO_SCENARIO_COOKIE}=${selected}; path=/; max-age=86400; SameSite=Lax${secure}`;
     router.refresh();
     setOpen(false);
   }

--- a/src/components/DemoScenarioPicker/__tests__/DemoScenarioPicker.test.tsx
+++ b/src/components/DemoScenarioPicker/__tests__/DemoScenarioPicker.test.tsx
@@ -178,7 +178,11 @@ describe("DemoScenarioPicker", () => {
       mockEnv.isLocalOrDemo = false;
 
       render(
-        isLocalOrDemo && <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />,
+        <>
+          {isLocalOrDemo && (
+            <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />
+          )}
+        </>,
       );
 
       expect(
@@ -190,7 +194,11 @@ describe("DemoScenarioPicker", () => {
       mockEnv.isLocalOrDemo = true;
 
       render(
-        isLocalOrDemo && <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />,
+        <>
+          {isLocalOrDemo && (
+            <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />
+          )}
+        </>,
       );
 
       expect(screen.getByRole("button", { name: /demo/i })).toBeInTheDocument();

--- a/src/components/DemoScenarioPicker/__tests__/DemoScenarioPicker.test.tsx
+++ b/src/components/DemoScenarioPicker/__tests__/DemoScenarioPicker.test.tsx
@@ -39,14 +39,14 @@ describe("DemoScenarioPicker", () => {
     vi.clearAllMocks();
     mockEnv.isLocalOrDemo = true;
     // biome-ignore lint/suspicious/noDocumentCookie: tests need to control the browser cookie directly
-    document.cookie = `${DEMO_SCENARIO_COOKIE}=; path=/; max-age=0`;
+    document.cookie = `${DEMO_SCENARIO_COOKIE}=; path=/`;
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  test("rendrer Demo-knappen med riktig label", () => {
+  test("renders the Demo button with correct label", () => {
     render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
 
     const button = screen.getByRole("button", { name: /demo/i });
@@ -54,7 +54,7 @@ describe("DemoScenarioPicker", () => {
     expect(button).toHaveTextContent("Demo");
   });
 
-  test("åpner modal ved klikk på Demo-knappen", async () => {
+  test("opens modal when clicking the Demo button", async () => {
     const user = userEvent.setup();
     render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
 
@@ -65,7 +65,7 @@ describe("DemoScenarioPicker", () => {
     ).toBeInTheDocument();
   });
 
-  test("viser alle AG-scenarioer som radio-knapper", async () => {
+  test("shows all AG scenarios as radio buttons", async () => {
     const user = userEvent.setup();
     render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
 
@@ -78,20 +78,19 @@ describe("DemoScenarioPicker", () => {
     }
   });
 
-  test("viser kun SM-scenarioer når SM-options sendes som prop", async () => {
+  test("shows only SM scenarios when SM options are passed as prop", async () => {
     const user = userEvent.setup();
     render(<DemoScenarioPicker scenarios={SM_SCENARIO_OPTIONS} />);
 
     await user.click(screen.getByRole("button", { name: /demo/i }));
 
-    // SM-scenarioer skal vises
     for (const option of SM_SCENARIO_OPTIONS) {
       expect(
         screen.getByRole("radio", { name: option.label }),
       ).toBeInTheDocument();
     }
 
-    // AG-only scenario "aktiv-utkast-og-tidligere" skal IKKE vises
+    // AG-only scenario "aktiv-utkast-og-tidligere" should NOT be shown
     const agOnlyOption = AG_SCENARIO_OPTIONS.find(
       (o) => !SM_SCENARIO_OPTIONS.some((s) => s.value === o.value),
     );
@@ -102,23 +101,21 @@ describe("DemoScenarioPicker", () => {
     }
   });
 
-  test("velger scenario og lagrer cookie før refresh", async () => {
+  test("selects scenario and saves cookie before refresh", async () => {
     const user = userEvent.setup();
     render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
 
     await user.click(screen.getByRole("button", { name: /demo/i }));
 
-    // Velg "Tom"-scenarioet
     await user.click(screen.getByRole("radio", { name: "Tom" }));
 
-    // Klikk "Bruk scenario"
     await user.click(screen.getByRole("button", { name: /Bruk scenario/i }));
 
     expect(document.cookie).toContain(`${DEMO_SCENARIO_COOKIE}=tom`);
     expect(mockRouter.refresh).toHaveBeenCalled();
   });
 
-  test("lukker modal ved Avbryt", async () => {
+  test("closes modal when clicking cancel", async () => {
     const user = userEvent.setup();
     render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
 
@@ -134,7 +131,7 @@ describe("DemoScenarioPicker", () => {
     ).not.toBeInTheDocument();
   });
 
-  test("modal viser 'Velg scenario'-tekst som legend", async () => {
+  test("modal shows 'Velg scenario' text as legend", async () => {
     const user = userEvent.setup();
     render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
 
@@ -143,20 +140,19 @@ describe("DemoScenarioPicker", () => {
     expect(screen.getByText("Velg scenario")).toBeInTheDocument();
   });
 
-  test("default-scenario er forhåndsvalgt ved åpning av modal", async () => {
+  test("default scenario is preselected when opening modal", async () => {
     const user = userEvent.setup();
     render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
 
     await user.click(screen.getByRole("button", { name: /demo/i }));
 
-    // Default er "aktiv-og-tidligere"
     const defaultRadio = screen.getByRole("radio", {
       name: "Aktiv plan + tidligere planer",
     });
     expect(defaultRadio).toBeChecked();
   });
 
-  test("forhåndsvelger scenario fra cookie", async () => {
+  test("preselects scenario from cookie", async () => {
     // biome-ignore lint/suspicious/noDocumentCookie: tests need to control the browser cookie directly
     document.cookie = `${DEMO_SCENARIO_COOKIE}=tom`;
 
@@ -168,13 +164,13 @@ describe("DemoScenarioPicker", () => {
     expect(screen.getByRole("radio", { name: "Tom" })).toBeChecked();
   });
 
-  describe("produksjonsbeskyttelse (isLocalOrDemo-guard)", () => {
+  describe("production guard (isLocalOrDemo)", () => {
     /**
-     * Layoutene bruker `{isLocalOrDemo && <DemoScenarioPicker ... />}`.
-     * Vi simulerer dette mønsteret her for å verifisere at pickeren
-     * ikke rendres når isLocalOrDemo er false (prod / dev-gcp).
+     * Layouts use `{isLocalOrDemo && <DemoScenarioPicker ... />}`.
+     * We simulate this pattern to verify the picker is not rendered
+     * when isLocalOrDemo is false (prod / dev-gcp).
      */
-    test("rendrer IKKE DemoScenarioPicker når isLocalOrDemo er false", () => {
+    test("does NOT render DemoScenarioPicker when isLocalOrDemo is false", () => {
       mockEnv.isLocalOrDemo = false;
 
       render(
@@ -190,7 +186,7 @@ describe("DemoScenarioPicker", () => {
       ).not.toBeInTheDocument();
     });
 
-    test("rendrer DemoScenarioPicker når isLocalOrDemo er true", () => {
+    test("renders DemoScenarioPicker when isLocalOrDemo is true", () => {
       mockEnv.isLocalOrDemo = true;
 
       render(

--- a/src/components/DemoScenarioPicker/__tests__/DemoScenarioPicker.test.tsx
+++ b/src/components/DemoScenarioPicker/__tests__/DemoScenarioPicker.test.tsx
@@ -1,0 +1,199 @@
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  AG_SCENARIO_OPTIONS,
+  DEMO_SCENARIO_COOKIE,
+  SM_SCENARIO_OPTIONS,
+} from "@/common/demoScenario";
+import { isLocalOrDemo } from "@/env-variables/envHelpers";
+import { mockRouter } from "@/test/mocks/nextNavigationMock";
+import { render } from "@/test/test-utils";
+import { DemoScenarioPicker } from "../DemoScenarioPicker";
+
+const mockEnv = vi.hoisted(() => ({ isLocalOrDemo: true }));
+
+vi.mock("next/navigation", async () => {
+  const { mockNextNavigation } = await import(
+    "@/test/mocks/nextNavigationMock"
+  );
+
+  return {
+    ...mockNextNavigation(),
+  };
+});
+
+vi.mock("@/env-variables/envHelpers", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/env-variables/envHelpers")>();
+  return {
+    ...original,
+    get isLocalOrDemo() {
+      return mockEnv.isLocalOrDemo;
+    },
+  };
+});
+
+describe("DemoScenarioPicker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.isLocalOrDemo = true;
+    // biome-ignore lint/suspicious/noDocumentCookie: tests need to control the browser cookie directly
+    document.cookie = `${DEMO_SCENARIO_COOKIE}=; path=/; max-age=0`;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("rendrer Demo-knappen med riktig label", () => {
+    render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
+
+    const button = screen.getByRole("button", { name: /demo/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent("Demo");
+  });
+
+  test("åpner modal ved klikk på Demo-knappen", async () => {
+    const user = userEvent.setup();
+    render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
+
+    await user.click(screen.getByRole("button", { name: /demo/i }));
+
+    expect(
+      screen.getByRole("heading", { name: /Demo-scenario/i }),
+    ).toBeInTheDocument();
+  });
+
+  test("viser alle AG-scenarioer som radio-knapper", async () => {
+    const user = userEvent.setup();
+    render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
+
+    await user.click(screen.getByRole("button", { name: /demo/i }));
+
+    for (const option of AG_SCENARIO_OPTIONS) {
+      expect(
+        screen.getByRole("radio", { name: option.label }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  test("viser kun SM-scenarioer når SM-options sendes som prop", async () => {
+    const user = userEvent.setup();
+    render(<DemoScenarioPicker scenarios={SM_SCENARIO_OPTIONS} />);
+
+    await user.click(screen.getByRole("button", { name: /demo/i }));
+
+    // SM-scenarioer skal vises
+    for (const option of SM_SCENARIO_OPTIONS) {
+      expect(
+        screen.getByRole("radio", { name: option.label }),
+      ).toBeInTheDocument();
+    }
+
+    // AG-only scenario "aktiv-utkast-og-tidligere" skal IKKE vises
+    const agOnlyOption = AG_SCENARIO_OPTIONS.find(
+      (o) => !SM_SCENARIO_OPTIONS.some((s) => s.value === o.value),
+    );
+    if (agOnlyOption) {
+      expect(
+        screen.queryByRole("radio", { name: agOnlyOption.label }),
+      ).not.toBeInTheDocument();
+    }
+  });
+
+  test("velger scenario og lagrer cookie før refresh", async () => {
+    const user = userEvent.setup();
+    render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
+
+    await user.click(screen.getByRole("button", { name: /demo/i }));
+
+    // Velg "Tom"-scenarioet
+    await user.click(screen.getByRole("radio", { name: "Tom" }));
+
+    // Klikk "Bruk scenario"
+    await user.click(screen.getByRole("button", { name: /Bruk scenario/i }));
+
+    expect(document.cookie).toContain(`${DEMO_SCENARIO_COOKIE}=tom`);
+    expect(mockRouter.refresh).toHaveBeenCalled();
+  });
+
+  test("lukker modal ved Avbryt", async () => {
+    const user = userEvent.setup();
+    render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
+
+    await user.click(screen.getByRole("button", { name: /demo/i }));
+    expect(
+      screen.getByRole("heading", { name: /Demo-scenario/i }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Avbryt/i }));
+
+    expect(
+      screen.queryByRole("heading", { name: /Demo-scenario/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("modal viser 'Velg scenario'-tekst som legend", async () => {
+    const user = userEvent.setup();
+    render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
+
+    await user.click(screen.getByRole("button", { name: /demo/i }));
+
+    expect(screen.getByText("Velg scenario")).toBeInTheDocument();
+  });
+
+  test("default-scenario er forhåndsvalgt ved åpning av modal", async () => {
+    const user = userEvent.setup();
+    render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
+
+    await user.click(screen.getByRole("button", { name: /demo/i }));
+
+    // Default er "aktiv-og-tidligere"
+    const defaultRadio = screen.getByRole("radio", {
+      name: "Aktiv plan + tidligere planer",
+    });
+    expect(defaultRadio).toBeChecked();
+  });
+
+  test("forhåndsvelger scenario fra cookie", async () => {
+    // biome-ignore lint/suspicious/noDocumentCookie: tests need to control the browser cookie directly
+    document.cookie = `${DEMO_SCENARIO_COOKIE}=tom`;
+
+    const user = userEvent.setup();
+    render(<DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />);
+
+    await user.click(screen.getByRole("button", { name: /demo/i }));
+
+    expect(screen.getByRole("radio", { name: "Tom" })).toBeChecked();
+  });
+
+  describe("produksjonsbeskyttelse (isLocalOrDemo-guard)", () => {
+    /**
+     * Layoutene bruker `{isLocalOrDemo && <DemoScenarioPicker ... />}`.
+     * Vi simulerer dette mønsteret her for å verifisere at pickeren
+     * ikke rendres når isLocalOrDemo er false (prod / dev-gcp).
+     */
+    test("rendrer IKKE DemoScenarioPicker når isLocalOrDemo er false", () => {
+      mockEnv.isLocalOrDemo = false;
+
+      render(
+        isLocalOrDemo && <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: /demo/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    test("rendrer DemoScenarioPicker når isLocalOrDemo er true", () => {
+      mockEnv.isLocalOrDemo = true;
+
+      render(
+        isLocalOrDemo && <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />,
+      );
+
+      expect(screen.getByRole("button", { name: /demo/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/OversiktSide/AnsattIkkeSykmeldtAlert.tsx
+++ b/src/components/OversiktSide/AnsattIkkeSykmeldtAlert.tsx
@@ -1,5 +1,5 @@
 import { Alert, BodyShort, Box, Heading } from "@navikt/ds-react";
-import { fetchOppfolgingsplanOversiktForAG } from "@/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt.ts";
+import { fetchOppfolgingsplanOversiktForAG } from "@/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt";
 
 export async function AnsattIkkeSykmeldtAlert({
   narmesteLederId,

--- a/src/components/OversiktSide/PlanListe/__tests__/NyPlanButtonHvisTomListe.test.tsx
+++ b/src/components/OversiktSide/PlanListe/__tests__/NyPlanButtonHvisTomListe.test.tsx
@@ -13,7 +13,9 @@ import { renderAsync } from "@/test/test-utils";
 import NyPlanButtonHvisTomListe from "../NyPlanButtonHvisTomListe";
 
 vi.mock("next/navigation", async () => {
-  const { mockNextNavigation } = await import("@/test/mocks/nextNavigationMock");
+  const { mockNextNavigation } = await import(
+    "@/test/mocks/nextNavigationMock"
+  );
 
   return mockNextNavigation();
 });

--- a/src/components/OversiktSide/PlanListe/__tests__/PlanListeForArbeidsgiver.test.tsx
+++ b/src/components/OversiktSide/PlanListe/__tests__/PlanListeForArbeidsgiver.test.tsx
@@ -13,7 +13,9 @@ import {
 import { renderAsync } from "@/test/test-utils";
 
 vi.mock("next/navigation", async () => {
-  const { mockNextNavigation } = await import("@/test/mocks/nextNavigationMock");
+  const { mockNextNavigation } = await import(
+    "@/test/mocks/nextNavigationMock"
+  );
 
   return mockNextNavigation();
 });

--- a/src/server/fetchData/arbeidsgiver/__tests__/fetchOppfolgingsplanOversikt.test.ts
+++ b/src/server/fetchData/arbeidsgiver/__tests__/fetchOppfolgingsplanOversikt.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from "vitest";
+import type { DemoScenario } from "@/common/demoScenario";
+import {
+  mockOversiktDataMedPlanerForAG,
+  mockOversiktDataTom,
+} from "@/server/fetchData/mockData/mockOversiktData";
+import { mockOversiktDataAktivOgTidligere } from "@/server/fetchData/mockData/mockOversiktDataVariants";
+
+// Opphev global mock fra vitest-setup.ts slik at vi kan teste den faktiske implementasjonen
+vi.unmock("@/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt");
+
+// Dynamisk import etter unmock for å få den ekte modulen
+const { getMockDataForScenario } = await import(
+  "../fetchOppfolgingsplanOversikt"
+);
+
+describe("getMockDataForScenario", () => {
+  test("returnerer tom oversikt for 'tom'-scenarioet", () => {
+    const result = getMockDataForScenario("tom");
+
+    expect(result).toEqual(mockOversiktDataTom);
+    expect(result.oversikt.aktivPlan).toBeNull();
+    expect(result.oversikt.utkast).toBeNull();
+    expect(result.oversikt.tidligerePlaner).toEqual([]);
+  });
+
+  test("returnerer aktiv plan og tidligere planer for 'aktiv-og-tidligere'", () => {
+    const result = getMockDataForScenario("aktiv-og-tidligere");
+
+    expect(result).toEqual(mockOversiktDataAktivOgTidligere);
+    expect(result.oversikt.aktivPlan).not.toBeNull();
+    expect(result.oversikt.utkast).toBeNull();
+    expect(result.oversikt.tidligerePlaner.length).toBeGreaterThan(0);
+  });
+
+  test("returnerer aktiv plan, utkast og tidligere planer for 'aktiv-utkast-og-tidligere'", () => {
+    const result = getMockDataForScenario("aktiv-utkast-og-tidligere");
+
+    expect(result).toEqual(mockOversiktDataMedPlanerForAG);
+    expect(result.oversikt.aktivPlan).not.toBeNull();
+    expect(result.oversikt.utkast).not.toBeNull();
+    expect(result.oversikt.tidligerePlaner.length).toBeGreaterThan(0);
+  });
+
+  test("kaster feil for ukjent scenario", () => {
+    expect(() => getMockDataForScenario("ukjent" as DemoScenario)).toThrow(
+      "Unknown demo scenario",
+    );
+  });
+});

--- a/src/server/fetchData/arbeidsgiver/__tests__/fetchOppfolgingsplanOversikt.test.ts
+++ b/src/server/fetchData/arbeidsgiver/__tests__/fetchOppfolgingsplanOversikt.test.ts
@@ -6,13 +6,13 @@ import {
 } from "@/server/fetchData/mockData/mockOversiktData";
 import { mockOversiktDataAktivOgTidligere } from "@/server/fetchData/mockData/mockOversiktDataVariants";
 
-// Opphev global mock fra vitest-setup.ts slik at vi kan teste den faktiske implementasjonen
+// Remove global mock from vitest-setup.ts so we can test the actual implementation
 vi.unmock("@/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt");
 
 import { getMockDataForScenario } from "@/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt";
 
 describe("getMockDataForScenario", () => {
-  test("returnerer tom oversikt for 'tom'-scenarioet", () => {
+  test("returns empty oversikt for the 'tom' scenario", () => {
     const result = getMockDataForScenario("tom");
 
     expect(result).toEqual(mockOversiktDataTom);
@@ -21,7 +21,7 @@ describe("getMockDataForScenario", () => {
     expect(result.oversikt.tidligerePlaner).toEqual([]);
   });
 
-  test("returnerer aktiv plan og tidligere planer for 'aktiv-og-tidligere'", () => {
+  test("returns active plan and previous plans for 'aktiv-og-tidligere'", () => {
     const result = getMockDataForScenario("aktiv-og-tidligere");
 
     expect(result).toEqual(mockOversiktDataAktivOgTidligere);
@@ -30,7 +30,7 @@ describe("getMockDataForScenario", () => {
     expect(result.oversikt.tidligerePlaner.length).toBeGreaterThan(0);
   });
 
-  test("returnerer aktiv plan, utkast og tidligere planer for 'aktiv-utkast-og-tidligere'", () => {
+  test("returns active plan, draft and previous plans for 'aktiv-utkast-og-tidligere'", () => {
     const result = getMockDataForScenario("aktiv-utkast-og-tidligere");
 
     expect(result).toEqual(mockOversiktDataMedPlanerForAG);
@@ -39,7 +39,7 @@ describe("getMockDataForScenario", () => {
     expect(result.oversikt.tidligerePlaner.length).toBeGreaterThan(0);
   });
 
-  test("kaster feil for ukjent scenario", () => {
+  test("throws error for unknown scenario", () => {
     expect(() => getMockDataForScenario("ukjent" as DemoScenario)).toThrow(
       "Unknown demo scenario",
     );

--- a/src/server/fetchData/arbeidsgiver/__tests__/fetchOppfolgingsplanOversikt.test.ts
+++ b/src/server/fetchData/arbeidsgiver/__tests__/fetchOppfolgingsplanOversikt.test.ts
@@ -9,10 +9,7 @@ import { mockOversiktDataAktivOgTidligere } from "@/server/fetchData/mockData/mo
 // Opphev global mock fra vitest-setup.ts slik at vi kan teste den faktiske implementasjonen
 vi.unmock("@/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt");
 
-// Dynamisk import etter unmock for å få den ekte modulen
-const { getMockDataForScenario } = await import(
-  "../fetchOppfolgingsplanOversikt"
-);
+import { getMockDataForScenario } from "@/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt";
 
 describe("getMockDataForScenario", () => {
   test("returnerer tom oversikt for 'tom'-scenarioet", () => {

--- a/src/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt.ts
+++ b/src/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt.ts
@@ -1,4 +1,9 @@
 import { getEndpointOversiktForAG } from "@/common/backend-endpoints";
+import {
+  DEMO_SCENARIO_COOKIE,
+  type DemoScenario,
+  parseDemoScenario,
+} from "@/common/demoScenario";
 import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import {
   type OppfolgingsplanerOversiktForAG,
@@ -8,18 +13,42 @@ import { getRedirectAfterLoginUrlForAG } from "@/server/auth/redirectToLogin";
 import { TokenXTargetApi } from "@/server/auth/tokenXExchange";
 import type { FetchGetResult } from "@/server/tokenXFetch/FetchResult";
 import { tokenXFetchGetWithResult } from "@/server/tokenXFetch/tokenXFetchGetWithResult";
-import { mockOversiktDataMedPlanerForAG } from "../mockData/mockOversiktData";
+import {
+  mockOversiktDataMedPlanerForAG,
+  mockOversiktDataTom,
+} from "../mockData/mockOversiktData";
+import { mockOversiktDataAktivOgTidligere } from "../mockData/mockOversiktDataVariants";
 import { simulateBackendDelay } from "../mockData/simulateBackendDelay";
+
+/** @visibleForTesting */
+export function getMockDataForScenario(scenario: DemoScenario) {
+  switch (scenario) {
+    case "tom":
+      return mockOversiktDataTom;
+    case "aktiv-og-tidligere":
+      return mockOversiktDataAktivOgTidligere;
+    case "aktiv-utkast-og-tidligere":
+      return mockOversiktDataMedPlanerForAG;
+    default: {
+      const _exhaustive: never = scenario;
+      throw new Error(`Unknown demo scenario: ${_exhaustive}`);
+    }
+  }
+}
 
 export async function fetchOppfolgingsplanOversiktForAG(
   narmesteLederId: string,
 ): Promise<FetchGetResult<OppfolgingsplanerOversiktForAG>> {
   if (isLocalOrDemo) {
+    const { cookies } = await import("next/headers");
+    const scenario = parseDemoScenario(
+      (await cookies()).get(DEMO_SCENARIO_COOKIE)?.value,
+    );
     await simulateBackendDelay();
 
     return {
       error: null,
-      data: mockOversiktDataMedPlanerForAG,
+      data: getMockDataForScenario(scenario),
     };
   }
 

--- a/src/server/fetchData/mockData/mockOversiktData.ts
+++ b/src/server/fetchData/mockData/mockOversiktData.ts
@@ -29,3 +29,8 @@ export const mockOversiktDataMedPlanerForSM: OppfolgingsplanerOversiktForSM = {
   aktiveOppfolgingsplaner: [mockAktivPlanData],
   tidligerePlaner: mockTidligerePlanerData,
 };
+
+export const mockOversiktDataTomForSM: OppfolgingsplanerOversiktForSM = {
+  aktiveOppfolgingsplaner: [],
+  tidligerePlaner: [],
+};

--- a/src/server/fetchData/mockData/mockOversiktDataVariants.ts
+++ b/src/server/fetchData/mockData/mockOversiktDataVariants.ts
@@ -71,3 +71,14 @@ export const mockOversiktDataEmptyNoAccess: OppfolgingsplanerOversiktForAG = {
     tidligerePlaner: [],
   },
 };
+
+// Active plan + previous plans, no draft
+export const mockOversiktDataAktivOgTidligere: OppfolgingsplanerOversiktForAG =
+  {
+    ...mockCommonAGResponseFields,
+    oversikt: {
+      utkast: null,
+      aktivPlan: mockAktivPlanData,
+      tidligerePlaner: mockTidligerePlanerData,
+    },
+  };

--- a/src/server/fetchData/sykmeldt/__tests__/fetchOppfolgingsplanOversiktForSM.test.ts
+++ b/src/server/fetchData/sykmeldt/__tests__/fetchOppfolgingsplanOversiktForSM.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import type { DemoScenario } from "@/common/demoScenario";
+import {
+  mockOversiktDataMedPlanerForSM,
+  mockOversiktDataTomForSM,
+} from "@/server/fetchData/mockData/mockOversiktData";
+import { getMockDataForScenarioSM } from "../fetchOppfolgingsplanOversiktForSM";
+
+describe("getMockDataForScenarioSM", () => {
+  test("returnerer tom oversikt for 'tom'-scenarioet", () => {
+    const result = getMockDataForScenarioSM("tom");
+
+    expect(result).toEqual(mockOversiktDataTomForSM);
+    expect(result.aktiveOppfolgingsplaner).toEqual([]);
+    expect(result.tidligerePlaner).toEqual([]);
+  });
+
+  test("returnerer planer for 'aktiv-og-tidligere'", () => {
+    const result = getMockDataForScenarioSM("aktiv-og-tidligere");
+
+    expect(result).toEqual(mockOversiktDataMedPlanerForSM);
+    expect(result.aktiveOppfolgingsplaner.length).toBeGreaterThan(0);
+    expect(result.tidligerePlaner.length).toBeGreaterThan(0);
+  });
+
+  test("returnerer same data for 'aktiv-utkast-og-tidligere' som for 'aktiv-og-tidligere'", () => {
+    const resultAktiv = getMockDataForScenarioSM("aktiv-og-tidligere");
+    const resultUtkast = getMockDataForScenarioSM("aktiv-utkast-og-tidligere");
+
+    expect(resultUtkast).toEqual(resultAktiv);
+    expect(resultUtkast).toEqual(mockOversiktDataMedPlanerForSM);
+  });
+
+  test("kaster feil for ukjent scenario", () => {
+    expect(() => getMockDataForScenarioSM("ukjent" as DemoScenario)).toThrow(
+      "Unknown demo scenario",
+    );
+  });
+});

--- a/src/server/fetchData/sykmeldt/__tests__/fetchOppfolgingsplanOversiktForSM.test.ts
+++ b/src/server/fetchData/sykmeldt/__tests__/fetchOppfolgingsplanOversiktForSM.test.ts
@@ -4,7 +4,7 @@ import {
   mockOversiktDataMedPlanerForSM,
   mockOversiktDataTomForSM,
 } from "@/server/fetchData/mockData/mockOversiktData";
-import { getMockDataForScenarioSM } from "../fetchOppfolgingsplanOversiktForSM";
+import { getMockDataForScenarioSM } from "@/server/fetchData/sykmeldt/fetchOppfolgingsplanOversiktForSM";
 
 describe("getMockDataForScenarioSM", () => {
   test("returnerer tom oversikt for 'tom'-scenarioet", () => {

--- a/src/server/fetchData/sykmeldt/__tests__/fetchOppfolgingsplanOversiktForSM.test.ts
+++ b/src/server/fetchData/sykmeldt/__tests__/fetchOppfolgingsplanOversiktForSM.test.ts
@@ -7,7 +7,7 @@ import {
 import { getMockDataForScenarioSM } from "@/server/fetchData/sykmeldt/fetchOppfolgingsplanOversiktForSM";
 
 describe("getMockDataForScenarioSM", () => {
-  test("returnerer tom oversikt for 'tom'-scenarioet", () => {
+  test("returns empty oversikt for the 'tom' scenario", () => {
     const result = getMockDataForScenarioSM("tom");
 
     expect(result).toEqual(mockOversiktDataTomForSM);
@@ -15,7 +15,7 @@ describe("getMockDataForScenarioSM", () => {
     expect(result.tidligerePlaner).toEqual([]);
   });
 
-  test("returnerer planer for 'aktiv-og-tidligere'", () => {
+  test("returns plans for 'aktiv-og-tidligere'", () => {
     const result = getMockDataForScenarioSM("aktiv-og-tidligere");
 
     expect(result).toEqual(mockOversiktDataMedPlanerForSM);
@@ -23,7 +23,7 @@ describe("getMockDataForScenarioSM", () => {
     expect(result.tidligerePlaner.length).toBeGreaterThan(0);
   });
 
-  test("returnerer same data for 'aktiv-utkast-og-tidligere' som for 'aktiv-og-tidligere'", () => {
+  test("returns same data for 'aktiv-utkast-og-tidligere' as for 'aktiv-og-tidligere'", () => {
     const resultAktiv = getMockDataForScenarioSM("aktiv-og-tidligere");
     const resultUtkast = getMockDataForScenarioSM("aktiv-utkast-og-tidligere");
 
@@ -31,7 +31,7 @@ describe("getMockDataForScenarioSM", () => {
     expect(resultUtkast).toEqual(mockOversiktDataMedPlanerForSM);
   });
 
-  test("kaster feil for ukjent scenario", () => {
+  test("throws error for unknown scenario", () => {
     expect(() => getMockDataForScenarioSM("ukjent" as DemoScenario)).toThrow(
       "Unknown demo scenario",
     );

--- a/src/server/fetchData/sykmeldt/fetchOppfolgingsplanOversiktForSM.ts
+++ b/src/server/fetchData/sykmeldt/fetchOppfolgingsplanOversiktForSM.ts
@@ -1,3 +1,8 @@
+import {
+  DEMO_SCENARIO_COOKIE,
+  type DemoScenario,
+  parseDemoScenario,
+} from "@/common/demoScenario";
 import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import { getServerEnv } from "@/env-variables/serverEnv";
 import {
@@ -7,13 +12,35 @@ import {
 import { getRedirectAfterLoginUrlForSM } from "@/server/auth/redirectToLogin";
 import { TokenXTargetApi } from "@/server/auth/tokenXExchange";
 import { tokenXFetchGet } from "@/server/tokenXFetch/tokenXFetchGet";
-import { mockOversiktDataMedPlanerForSM } from "../mockData/mockOversiktData";
+import {
+  mockOversiktDataMedPlanerForSM,
+  mockOversiktDataTomForSM,
+} from "../mockData/mockOversiktData";
 import { simulateBackendDelay } from "../mockData/simulateBackendDelay";
+
+/** @visibleForTesting */
+export function getMockDataForScenarioSM(scenario: DemoScenario) {
+  switch (scenario) {
+    case "tom":
+      return mockOversiktDataTomForSM;
+    case "aktiv-og-tidligere":
+    case "aktiv-utkast-og-tidligere":
+      return mockOversiktDataMedPlanerForSM;
+    default: {
+      const _exhaustive: never = scenario;
+      throw new Error(`Unknown demo scenario: ${_exhaustive}`);
+    }
+  }
+}
 
 export async function fetchOppfolgingsplanOversiktForSM(): Promise<OppfolgingsplanerOversiktForSM> {
   if (isLocalOrDemo) {
+    const { cookies } = await import("next/headers");
+    const scenario = parseDemoScenario(
+      (await cookies()).get(DEMO_SCENARIO_COOKIE)?.value,
+    );
     await simulateBackendDelay();
-    return mockOversiktDataMedPlanerForSM;
+    return getMockDataForScenarioSM(scenario);
   }
 
   return await tokenXFetchGet({


### PR DESCRIPTION
## Beskrivelse

Demo scenario picker — en flytende knapp som åpner en modal der utviklere kan bytte mellom ulike mock-data-scenarioer i local/demo-miljø. Bruker cookie for å lagre valgt scenario, som leses server-side for å returnere riktig mock-data.

## Endringer

- `src/common/demoScenario.ts`: DemoScenario-type (utledet fra `as const`-array), cookie-konstant, parser, scenario-opsjoner for AG/SM
- `src/components/DemoScenarioPicker/DemoScenarioPicker.tsx`: Klient-komponent med flytende knapp + Aksel Modal/RadioGroup, cookie-basert
- `src/app/[narmesteLederId]/layout.tsx`: Rendrer DemoScenarioPicker bak `isLocalOrDemo`-guard (AG)
- `src/app/sykmeldt/layout.tsx`: Samme for SM
- `src/app/sykmeldt/page.tsx`: Forenklet signatur (fjernet searchParams)
- `src/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt.ts`: Leser demo-cookie via dynamisk import bak `isLocalOrDemo`
- `src/server/fetchData/sykmeldt/fetchOppfolgingsplanOversiktForSM.ts`: Samme for SM
- `src/server/fetchData/mockData/mockOversiktData.ts`: SM mock-data-varianter + tom AG
- `src/server/fetchData/mockData/mockOversiktDataVariants.ts`: AG mock-data-varianter
- `src/components/OversiktSide/AnsattIkkeSykmeldtAlert.tsx`: Fjernet scenario-prop

### Tester (6 nye filer, 25 tester)

- `src/common/__tests__/demoScenario.test.ts`: 6 tester for parseDemoScenario
- `src/components/DemoScenarioPicker/__tests__/DemoScenarioPicker.test.tsx`: 11 tester for UI + guard
- `src/server/fetchData/arbeidsgiver/__tests__/fetchOppfolgingsplanOversikt.test.ts`: 4 tester for AG mock-data
- `src/server/fetchData/sykmeldt/__tests__/fetchOppfolgingsplanOversiktForSM.test.ts`: 4 tester for SM mock-data

## Issue

Ingen issue — intern demo-funksjonalitet.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Merknader fra inspeksjon

Gjennomgått av inspektør-claude (Opus) og inspektør-gpt (GPT). Dom: 😐 leveranseklart med merknader.

Kjente begrensninger:
- Scenario-valg gjelder kun oversiktsidene. Andre fetch-funksjoner (fetchAktivPlan, fetchUtkastPlan, etc.) er ikke scenario-bevisste ennå.
- SM mapper `aktiv-utkast-og-tidligere` til samme data som `aktiv-og-tidligere` (SM har ikke utkast-konsept).