### PR TITLE
feat(lumi): erstatt medvirkning-survey med nytteverdi-survey for sykmeldt

### DIFF
--- a/src/app/sykmeldt/aktiv-plan/[planId]/page.tsx
+++ b/src/app/sykmeldt/aktiv-plan/[planId]/page.tsx
@@ -14,7 +14,7 @@ export default async function AktivPlanPageForSM({
       <AktivPlanForSM planId={planId} />
 
       <Lumi
-        feedbackId="Oppfølgingsplan medvirkning - sykmeldt"
+        feedbackId="Oppfølgingsplan nytteverdi - sykmeldt"
         behavior={{ questionLayout: "steps", showProgress: true }}
         survey={lumiSurveySM}
       />

--- a/src/ui/Lumi/lumiSurveySM.test.ts
+++ b/src/ui/Lumi/lumiSurveySM.test.ts
@@ -1,48 +1,36 @@
 import { expect, test } from "vitest";
 import { lumiSurveySM } from "./lumiSurveySM";
 
-test("uses the medvirkning survey configuration for sykmeldt", () => {
-  expect(lumiSurveySM.type).toBe("custom");
+test("uses the nytteverdi survey configuration for sykmeldt", () => {
+  expect(lumiSurveySM.type).toBe("rating");
   expect(lumiSurveySM.questions).toHaveLength(4);
 
   expect(lumiSurveySM.questions).toEqual([
     expect.objectContaining({
-      id: "opplevelse",
+      id: "nytteverdi",
       type: "rating",
       variant: "emoji",
       required: true,
     }),
     expect.objectContaining({
-      id: "samarbeid",
-      type: "singleChoice",
-      required: true,
-      options: [
-        { value: "sammen", label: "Ja, vi satt sammen og lagde den" },
-        {
-          value: "snakket",
-          label: "Ja, vi snakket sammen, og lederen min lagde den etterpå",
-        },
-        {
-          value: "uten-meg",
-          label: "Nei, lederen min lagde den uten at vi snakket sammen",
-        },
-        { value: "annet", label: "Annet" },
-      ],
-    }),
-    expect.objectContaining({
-      id: "deling-holdning",
-      type: "singleChoice",
-      required: true,
-      options: [
-        { value: "helt-greit", label: "Helt greit" },
-        { value: "greit", label: "Greit" },
-        { value: "ikke-greit", label: "Ikke greit" },
-      ],
-    }),
-    expect.objectContaining({
-      id: "annet",
+      id: "nytteverdi-utdypning",
       type: "text",
       required: false,
+    }),
+    expect.objectContaining({
+      id: "gjenkjennelse",
+      type: "singleChoice",
+      required: true,
+      options: [
+        { value: "ja", label: "Ja" },
+        { value: "nei", label: "Nei" },
+      ],
+    }),
+    expect.objectContaining({
+      id: "gjenkjennelse-utdypning",
+      type: "text",
+      required: false,
+      visibleIf: { questionId: "gjenkjennelse", operator: "EQ", value: "nei" },
     }),
   ]);
 });

--- a/src/ui/Lumi/lumiSurveySM.ts
+++ b/src/ui/Lumi/lumiSurveySM.ts
@@ -1,71 +1,54 @@
 import type { LumiSurveyConfig } from "@navikt/lumi-survey";
 
 export const lumiSurveySM: LumiSurveyConfig = {
-  type: "custom",
+  type: "rating",
   questions: [
     {
-      id: "opplevelse",
+      id: "nytteverdi",
       type: "rating",
       variant: "emoji",
       required: true,
-      prompt:
-        "Hvordan opplevde du samarbeidet med lederen din da oppfølgingsplanen ble laget?",
+      prompt: "Er oppfølgingsplanen til hjelp for deg?",
       description:
         "Svarene du sender inn er anonyme, og blir brukt til videreutvikling av oppfølgingsplanen.",
     },
     {
-      id: "samarbeid",
-      type: "singleChoice",
-      required: true,
-      prompt:
-        "Snakket du med lederen din om innholdet i planen før den ble laget?",
-      options: [
-        {
-          value: "sammen",
-          label: "Ja, vi satt sammen og lagde den",
-        },
-        {
-          value: "snakket",
-          label: "Ja, vi snakket sammen, og lederen min lagde den etterpå",
-        },
-        {
-          value: "uten-meg",
-          label: "Nei, lederen min lagde den uten at vi snakket sammen",
-        },
-        {
-          value: "annet",
-          label: "Annet",
-        },
-      ],
-    },
-    {
-      id: "deling-holdning",
-      type: "singleChoice",
-      required: true,
-      prompt:
-        "Hva synes du om at lederen din kan dele planen med fastlegen din og Nav uten at du godkjenner den?",
-      options: [
-        {
-          value: "helt-greit",
-          label: "Helt greit",
-        },
-        {
-          value: "greit",
-          label: "Greit",
-        },
-        {
-          value: "ikke-greit",
-          label: "Ikke greit",
-        },
-      ],
-    },
-    {
-      id: "annet",
+      id: "nytteverdi-utdypning",
       type: "text",
-      prompt: "Er det noe du vil legge til?",
+      prompt:
+        "Beskriv gjerne hva som gjør at den er til hjelp/ikke til hjelp for deg?",
       required: false,
       minRows: 3,
       maxLength: 500,
+    },
+    {
+      id: "gjenkjennelse",
+      type: "singleChoice",
+      required: true,
+      prompt: "Kjenner du deg igjen i innholdet i planen?",
+      options: [
+        {
+          value: "ja",
+          label: "Ja",
+        },
+        {
+          value: "nei",
+          label: "Nei",
+        },
+      ],
+    },
+    {
+      id: "gjenkjennelse-utdypning",
+      type: "text",
+      prompt: "Beskriv gjerne hvorfor?",
+      required: false,
+      minRows: 3,
+      maxLength: 500,
+      visibleIf: {
+        questionId: "gjenkjennelse",
+        operator: "EQ",
+        value: "nei",
+      },
     },
   ],
 };


### PR DESCRIPTION
## Endring

Erstatter den eksisterende lumi-survey for sykmeldt (medvirkning) med en ny nytteverdi-survey.

### Nye spørsmål
1. ⭐ **Rating** (emoji 1-5): *Er oppfølgingsplanen til hjelp for deg?*
2. 📝 **Fritekst** (valgfri): *Beskriv gjerne hva som gjør at den er til hjelp/ikke til hjelp for deg?*
3. ✅ **Ja/Nei**: *Kjenner du deg igjen i innholdet i planen?*
4. 📝 **Fritekst** (valgfri, kun ved Nei): *Beskriv gjerne hvorfor?*

### Endringer
- `lumiSurveySM.ts` — ny survey-konfigurasjon med 4 spørsmål
- `page.tsx` — ny feedbackId: `Oppfølgingsplan nytteverdi - sykmeldt`
- `lumiSurveySM.test.ts` — oppdatert test

### Designvalg
- `type: "rating"` (ikke `custom`) — gir bedre visualiseringer i Lumi-dashboardet
- Ingen `visibleIf` på spørsmål 2 — step layout håndterer sekvensieringen
- `visibleIf` kun på spørsmål 4 — betinget på svar "Nei"