### PR TITLE
fix(utkast): blokker auto-lagring ved ugyldig input over tegngrense

### DIFF
--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/Buttons/__tests__/AktivPlanButtons.test.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/Buttons/__tests__/AktivPlanButtons.test.tsx
@@ -1,12 +1,14 @@
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { mockAnalytics } from "@/test/mocks/analyticsMock";
 import { mockAkselModal } from "@/test/mocks/akselModalMock";
+import { mockAnalytics } from "@/test/mocks/analyticsMock";
 import { render } from "@/test/test-utils";
 import { AktivPlanButtons } from "../AktivPlanButtons";
 
 vi.mock("next/navigation", async () => {
-  const { mockNextNavigation } = await import("@/test/mocks/nextNavigationMock");
+  const { mockNextNavigation } = await import(
+    "@/test/mocks/nextNavigationMock"
+  );
 
   return mockNextNavigation();
 });

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/__tests__/DelAktivPlanMedLegeEllerNav.test.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/__tests__/DelAktivPlanMedLegeEllerNav.test.tsx
@@ -12,7 +12,9 @@ const MOCK_PLAN_ID = "test-plan-123";
 const MOCK_LEDER_ID = "test-leder-123";
 
 vi.mock("next/navigation", async () => {
-  const { mockNextNavigation } = await import("@/test/mocks/nextNavigationMock");
+  const { mockNextNavigation } = await import(
+    "@/test/mocks/nextNavigationMock"
+  );
 
   return mockNextNavigation();
 });

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/LagNyPlanModal.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/LagNyPlanModal.tsx
@@ -2,7 +2,12 @@
 
 import { Alert, BodyLong, Modal, VStack } from "@navikt/ds-react";
 import { useParams, useRouter } from "next/navigation";
-import { startTransition, useActionState, useState, useTransition } from "react";
+import {
+  startTransition,
+  useActionState,
+  useState,
+  useTransition,
+} from "react";
 import { knappKlikket } from "@/common/analytics/events-and-properties/knappKlikket-properties";
 import { logAnalyticsEvent } from "@/common/analytics/logAnalyticsEvent";
 import { getAGOpprettNyPlanHref } from "@/common/route-hrefs";
@@ -71,8 +76,7 @@ export function LagNyPlanModal({ ref, hasUtkast }: Props) {
       <Modal.Body>
         <VStack gap="space-16">
           <BodyLong>
-            Du kan ta utgangspunkt i den forrige planen, eller begynne på
-            nytt.
+            Du kan ta utgangspunkt i den forrige planen, eller begynne på nytt.
           </BodyLong>
 
           {hasUtkast && (

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/__tests__/LagNyPlanModal.test.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/__tests__/LagNyPlanModal.test.tsx
@@ -35,7 +35,9 @@ vi.mock("react", async () => {
 });
 
 vi.mock("next/navigation", async () => {
-  const { mockNextNavigation } = await import("@/test/mocks/nextNavigationMock");
+  const { mockNextNavigation } = await import(
+    "@/test/mocks/nextNavigationMock"
+  );
 
   return mockNextNavigation();
 });

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useOppfolgingsplanForm.ts
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useOppfolgingsplanForm.ts
@@ -56,7 +56,10 @@ export default function useOppfolgingsplanForm({
     },
     listeners: {
       onChange: ({ formApi }) =>
-        startLagreUtkastIfChanges({ values: formApi.state.values }),
+        startLagreUtkastIfChanges({
+          values: formApi.state.values,
+          skipIfInvalid: true,
+        }),
       onChangeDebounceMs: SAVE_UTKAST_DEBOUNCE_DELAY,
     },
     onSubmitInvalid: () => {

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useOppfolgingsplanUtkastLagring.ts
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useOppfolgingsplanUtkastLagring.ts
@@ -1,6 +1,9 @@
 import { useParams } from "next/navigation";
 import { startTransition, useActionState } from "react";
-import type { OppfolgingsplanFormUnderArbeid } from "@/schema/oppfolgingsplanForm/formValidationSchemas";
+import {
+  type OppfolgingsplanFormUnderArbeid,
+  oppfolgingsplanFormUnderArbeidSchema,
+} from "@/schema/oppfolgingsplanForm/formValidationSchemas";
 import { lagreUtkastServerAction } from "@/server/actions/lagreUtkast";
 import type { FetchResultError } from "@/server/tokenXFetch/FetchResult";
 
@@ -51,9 +54,11 @@ export default function useOppfolgingsplanUtkastLagring({
     {
       values,
       onSuccess,
+      skipIfInvalid,
     }: {
       values: OppfolgingsplanFormUnderArbeid;
       onSuccess?: () => void;
+      skipIfInvalid?: boolean;
     },
   ) {
     /* Uten denne sjekken, slik det er satt opp nå, vil det alltid bli trigget
@@ -73,6 +78,12 @@ export default function useOppfolgingsplanUtkastLagring({
     let newActionState: LagreUtkastActionState;
 
     if (hasValuesChangedFromPreviousSave) {
+      const { success: isValid } =
+        oppfolgingsplanFormUnderArbeidSchema.safeParse(values);
+      if (!isValid && skipIfInvalid) {
+        return previousState;
+      }
+
       const result = await lagreUtkastServerAction(narmesteLederId, values);
 
       if (result.error) {
@@ -102,12 +113,14 @@ export default function useOppfolgingsplanUtkastLagring({
   function startLagreUtkastIfChanges({
     values,
     onSuccess,
+    skipIfInvalid,
   }: {
     values: OppfolgingsplanFormUnderArbeid;
     onSuccess?: () => void;
+    skipIfInvalid?: boolean;
   }) {
     startTransition(() => {
-      lagreUtkastIfChangesAction({ values, onSuccess });
+      lagreUtkastIfChangesAction({ values, onSuccess, skipIfInvalid });
     });
   }
 

--- a/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useOppfolgingsplanUtkastLagring.ts
+++ b/src/components/NyPlanSide/FyllUtPlanSteg/form/hooks/useOppfolgingsplanUtkastLagring.ts
@@ -78,10 +78,12 @@ export default function useOppfolgingsplanUtkastLagring({
     let newActionState: LagreUtkastActionState;
 
     if (hasValuesChangedFromPreviousSave) {
-      const { success: isValid } =
-        oppfolgingsplanFormUnderArbeidSchema.safeParse(values);
-      if (!isValid && skipIfInvalid) {
-        return previousState;
+      if (skipIfInvalid === true) {
+        const { success: isValid } =
+          oppfolgingsplanFormUnderArbeidSchema.safeParse(values);
+        if (!isValid) {
+          return previousState;
+        }
       }
 
       const result = await lagreUtkastServerAction(narmesteLederId, values);

--- a/src/components/NyPlanSide/LagPlanVeiviser.autoLagring.test.tsx
+++ b/src/components/NyPlanSide/LagPlanVeiviser.autoLagring.test.tsx
@@ -165,9 +165,7 @@ describe("LagPlanVeiviser continuous autosaving while typing feature", () => {
       await vi.advanceTimersByTimeAsync(SAVE_UTKAST_DEBOUNCE_DELAY + 100);
     });
 
-    // Auto-save should NOT send invalid data to the server
-    // BUG #761: Currently auto-save sends data without validating maxLength,
-    // so this test FAILS because lagreUtkastServerAction IS called with >2000 chars
+    // Auto-save should not send invalid data to the server
     expect(lagreUtkastSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/components/NyPlanSide/LagPlanVeiviser.autoLagring.test.tsx
+++ b/src/components/NyPlanSide/LagPlanVeiviser.autoLagring.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   DEMO_SIMULATED_BACKEND_DELAY_MS,
   SAVE_UTKAST_DEBOUNCE_DELAY,
+  TEXT_FIELD_MAX_LENGTH,
 } from "@/common/app-config";
 import * as lagreUtkastModule from "@/server/actions/lagreUtkast";
 import { formLabels } from "./form-labels";
@@ -142,6 +143,31 @@ describe("LagPlanVeiviser continuous autosaving while typing feature", () => {
     });
 
     // Verify no saving has happened
+    expect(lagreUtkastSpy).not.toHaveBeenCalled();
+  });
+
+  test("should not autosave when text exceeds maxLength", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    await renderLagPlanVeiviserComponent(createMockLagretUtkastResponse());
+
+    const typiskArbeidshverdagTextarea = screen.getByLabelText(
+      formLabels.typiskArbeidshverdag.label,
+    );
+
+    // Paste text that exceeds the max length (2001 chars > 2000 limit)
+    const tooLongText = "a".repeat(TEXT_FIELD_MAX_LENGTH + 1);
+    await user.click(typiskArbeidshverdagTextarea);
+    await user.paste(tooLongText);
+
+    // Advance timers past the debounce delay to trigger autosave
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SAVE_UTKAST_DEBOUNCE_DELAY + 100);
+    });
+
+    // Auto-save should NOT send invalid data to the server
+    // BUG #761: Currently auto-save sends data without validating maxLength,
+    // so this test FAILS because lagreUtkastServerAction IS called with >2000 chars
     expect(lagreUtkastSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/server/actions/lagreUtkast.ts
+++ b/src/server/actions/lagreUtkast.ts
@@ -55,7 +55,7 @@ export async function lagreUtkastServerAction(
     }
 
     if (!isFormValuesValid) {
-      logger.error(
+      logger.warn(
         `lagreUtkastServerAction formValues validation error: ${inputValidationError.message}`,
       );
     }

--- a/src/test/mocks/akselModalMock.tsx
+++ b/src/test/mocks/akselModalMock.tsx
@@ -18,7 +18,9 @@ interface ModalSectionProps {
 
 export async function mockAkselModal() {
   const actual =
-    await vi.importActual<typeof import("@navikt/ds-react")>("@navikt/ds-react");
+    await vi.importActual<typeof import("@navikt/ds-react")>(
+      "@navikt/ds-react",
+    );
 
   const Modal = Object.assign(
     ({ children, header, onClose, onBeforeClose }: ModalProps) => (


### PR DESCRIPTION
## Beskrivelse

Auto-lagring av utkast sendte ugyldige verdier (>2000 tegn) til server action uten klient-side validering. Server logget error i prod, og brukeren fikk en generisk feilmelding uten nyttig kontekst.

Denne PR-en legger til en safeParse-guard i utkast-lagringsflyten som blokkerer auto-lagring når input er ugyldig, og endrer server-side logging fra `error` til `warn` for forventet valideringsfeil (defense-in-depth).

## Endringer

- `useOppfolgingsplanUtkastLagring.ts`: safeParse-guard med `skipIfInvalid`-parameter som blokkerer auto-lagring ved ugyldig input
- `useOppfolgingsplanForm.ts`: Auto-lagring sender `skipIfInvalid: true`, manuell lagring (knapper) sender ikke parameteren
- `LagPlanVeiviser.autoLagring.test.tsx`: Ny test som verifiserer at auto-lagring ikke kalles med >2000 tegn
- `lagreUtkast.ts`: Endret `logger.error` → `logger.warn` for forventet valideringsfeil (defense-in-depth)

## Issue

Closes #761

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Verifisering

- 99/99 tester passerer
- Build OK
- Lint OK