### PR TITLE
ci(hovmester): split verify and automerge workflows

### DIFF
--- a/.github/workflows/hovmester-automerge.yml
+++ b/.github/workflows/hovmester-automerge.yml
@@ -1,0 +1,166 @@
+name: Automerge hovmester sync
+
+on:
+  workflow_run:
+    workflows: ["Verify hovmester sync"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  automerge-hovmester-sync:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Re-verify sync PR
+        id: verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_BRANCH: "hovmester-sync"
+          EXPECTED_PR_AUTHOR: "teamesyfo-automerge[bot]"
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          OWNER="${REPO%%/*}"
+
+          RUN_EVENT=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.event')
+          RUN_CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.conclusion')
+          RUN_HEAD_BRANCH=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_branch')
+          RUN_HEAD_SHA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_sha')
+          RUN_HEAD_REPO=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_repository.full_name')
+
+          if [[ "$RUN_CONCLUSION" != "success" ]]; then
+            echo "::error::Unexpected workflow conclusion: $RUN_CONCLUSION"
+            exit 1
+          fi
+
+          if [[ "$RUN_EVENT" != "pull_request" ]]; then
+            echo "Workflow run event is $RUN_EVENT - skipping automerge"
+            exit 0
+          fi
+
+          if [[ "$RUN_HEAD_BRANCH" != "$EXPECTED_BRANCH" ]]; then
+            echo "Workflow run branch is $RUN_HEAD_BRANCH - skipping automerge"
+            exit 0
+          fi
+
+          if [[ "$RUN_HEAD_REPO" != "$REPO" ]]; then
+            echo "::error::Unexpected workflow head repository: $RUN_HEAD_REPO"
+            exit 1
+          fi
+
+          PR_COUNT=$(gh api "repos/${REPO}/pulls?state=open&head=${OWNER}:${EXPECTED_BRANCH}&base=${DEFAULT_BRANCH}" --jq 'length')
+
+          if [[ "$PR_COUNT" == "0" ]]; then
+            echo "No open hovmester sync PR found - skipping automerge"
+            exit 0
+          fi
+
+          if [[ "$PR_COUNT" != "1" ]]; then
+            echo "::error::Expected exactly one open hovmester sync PR, found $PR_COUNT"
+            exit 1
+          fi
+
+          PR_NUMBER=$(gh api "repos/${REPO}/pulls?state=open&head=${OWNER}:${EXPECTED_BRANCH}&base=${DEFAULT_BRANCH}" --jq '.[0].number')
+          PR_AUTHOR=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.user.login')
+          HEAD_REF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.ref')
+          HEAD_REPO=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')
+          HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
+
+          if [[ "$PR_AUTHOR" != "$EXPECTED_PR_AUTHOR" ]]; then
+            echo "::error::Unexpected PR author: $PR_AUTHOR"
+            echo "Expected PR author: $EXPECTED_PR_AUTHOR"
+            exit 1
+          fi
+
+          if [[ "$HEAD_REF" != "$EXPECTED_BRANCH" ]]; then
+            echo "::error::Unexpected PR branch: $HEAD_REF"
+            echo "Expected PR branch: $EXPECTED_BRANCH"
+            exit 1
+          fi
+
+          if [[ "$HEAD_REPO" != "$REPO" ]]; then
+            echo "::error::Unexpected PR head repository: $HEAD_REPO"
+            exit 1
+          fi
+
+          if [[ "$HEAD_SHA" != "$RUN_HEAD_SHA" ]]; then
+            echo "::error::Head SHA mismatch between verify run and PR"
+            echo "Workflow run head SHA: $RUN_HEAD_SHA"
+            echo "Pull request head SHA: $HEAD_SHA"
+            exit 1
+          fi
+
+          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --paginate --jq '.[] | .filename, (.previous_filename // empty)')
+
+          if [[ -z "$FILES" ]]; then
+            echo "::error::No files found from pull request files API; failing closed"
+            exit 1
+          fi
+
+          echo "Changed files:"
+          echo "$FILES"
+
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+
+            if [[ "$file" == .github/workflows/* ]]; then
+              echo "::error::Workflow changes are not allowed in hovmester sync PRs: $file"
+              exit 1
+            fi
+
+            case "$file" in
+              .github/agents/*|\
+              .github/instructions/*|\
+              .github/skills/*|\
+              .github/ISSUE_TEMPLATE/*|\
+              .github/PULL_REQUEST_TEMPLATE.md|\
+              .github/.hovmester-manifest.json|\
+              .github/.copilot-kitchen-manifest.json)
+                ;;
+              *)
+                echo "::error::File outside sync scope: $file"
+                echo "Only hovmester-managed paths are allowed in sync PRs"
+                exit 1
+                ;;
+            esac
+          done <<< "$FILES"
+
+          echo "✅ Sync PR re-verified"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Approve sync PR
+        if: steps.verify.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.verify.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "Auto-approved after workflow_run re-verification ✅"
+
+      - name: Create GitHub App token for merge
+        if: steps.verify.outputs.pr_number != ''
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: "2906300"
+          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
+
+      - name: Enable auto-merge
+        if: steps.verify.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_SHA: ${{ steps.verify.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.verify.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash --match-head-commit "$HEAD_SHA"

--- a/.github/workflows/hovmester-automerge.yml
+++ b/.github/workflows/hovmester-automerge.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   automerge-hovmester-sync:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_branch == 'hovmester-sync' && github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/hovmester-automerge.yml
+++ b/.github/workflows/hovmester-automerge.yml
@@ -3,12 +3,8 @@ name: Automerge hovmester sync
 on:
   workflow_run:
     workflows: ["Verify hovmester sync"]
+    branches: [hovmester-sync]
     types: [completed]
-
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
 
 concurrency:
   group: hovmester-automerge
@@ -16,6 +12,8 @@ concurrency:
 
 jobs:
   automerge-hovmester-sync:
+    permissions:
+      pull-requests: write
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_branch == 'hovmester-sync' && github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/hovmester-automerge.yml
+++ b/.github/workflows/hovmester-automerge.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: hovmester-automerge
+  cancel-in-progress: false
+
 jobs:
   automerge-hovmester-sync:
     if: github.event.workflow_run.conclusion == 'success'
@@ -24,17 +28,14 @@ jobs:
           EXPECTED_BRANCH: "hovmester-sync"
           EXPECTED_PR_AUTHOR: "teamesyfo-automerge[bot]"
           REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-
-          OWNER="${REPO%%/*}"
-
-          RUN_EVENT=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.event')
-          RUN_CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.conclusion')
-          RUN_HEAD_BRANCH=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_branch')
-          RUN_HEAD_SHA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_sha')
-          RUN_HEAD_REPO=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_repository.full_name')
 
           if [[ "$RUN_CONCLUSION" != "success" ]]; then
             echo "::error::Unexpected workflow conclusion: $RUN_CONCLUSION"
@@ -56,19 +57,21 @@ jobs:
             exit 1
           fi
 
-          PR_COUNT=$(gh api "repos/${REPO}/pulls?state=open&head=${OWNER}:${EXPECTED_BRANCH}&base=${DEFAULT_BRANCH}" --jq 'length')
+          PR_NUMBERS=$(gh api "repos/${REPO}/pulls?state=open&head=${REPO_OWNER}:${EXPECTED_BRANCH}&base=${DEFAULT_BRANCH}" \
+            --jq '.[].number')
+          PR_COUNT=$(printf '%s\n' "$PR_NUMBERS" | sed '/^$/d' | wc -l | tr -d ' ')
 
-          if [[ "$PR_COUNT" == "0" ]]; then
+          if [[ "$PR_COUNT" -eq 0 ]]; then
             echo "No open hovmester sync PR found - skipping automerge"
             exit 0
           fi
 
-          if [[ "$PR_COUNT" != "1" ]]; then
+          if [[ "$PR_COUNT" -ne 1 ]]; then
             echo "::error::Expected exactly one open hovmester sync PR, found $PR_COUNT"
             exit 1
           fi
 
-          PR_NUMBER=$(gh api "repos/${REPO}/pulls?state=open&head=${OWNER}:${EXPECTED_BRANCH}&base=${DEFAULT_BRANCH}" --jq '.[0].number')
+          PR_NUMBER=$(printf '%s\n' "$PR_NUMBERS" | sed -n '1p')
           PR_AUTHOR=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.user.login')
           HEAD_REF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.ref')
           HEAD_REPO=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')
@@ -153,6 +156,8 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: "2906300"
+          permission-contents: write
+          permission-pull-requests: write
           private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
 
       - name: Enable auto-merge

--- a/.github/workflows/hovmester-automerge.yml
+++ b/.github/workflows/hovmester-automerge.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: hovmester-automerge
+  cancel-in-progress: false
+
 jobs:
   automerge-hovmester-sync:
     if: github.event.workflow_run.conclusion == 'success'
@@ -24,17 +28,14 @@ jobs:
           EXPECTED_BRANCH: "hovmester-sync"
           EXPECTED_PR_AUTHOR: "teamesyfo-automerge[bot]"
           REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-
-          OWNER="${REPO%%/*}"
-
-          RUN_EVENT=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.event')
-          RUN_CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.conclusion')
-          RUN_HEAD_BRANCH=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_branch')
-          RUN_HEAD_SHA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_sha')
-          RUN_HEAD_REPO=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_repository.full_name')
 
           if [[ "$RUN_CONCLUSION" != "success" ]]; then
             echo "::error::Unexpected workflow conclusion: $RUN_CONCLUSION"
@@ -56,19 +57,21 @@ jobs:
             exit 1
           fi
 
-          PR_COUNT=$(gh api "repos/${REPO}/pulls?state=open&head=${OWNER}:${EXPECTED_BRANCH}&base=${DEFAULT_BRANCH}" --jq 'length')
+          PR_NUMBERS=$(gh api "repos/${REPO}/pulls?state=open&head=${REPO_OWNER}:${EXPECTED_BRANCH}&base=${DEFAULT_BRANCH}" \
+            --jq '.[].number')
+          PR_COUNT=$(printf '%s\n' "$PR_NUMBERS" | sed '/^$/d' | wc -l | tr -d ' ')
 
-          if [[ "$PR_COUNT" == "0" ]]; then
+          if [[ "$PR_COUNT" -eq 0 ]]; then
             echo "No open hovmester sync PR found - skipping automerge"
             exit 0
           fi
 
-          if [[ "$PR_COUNT" != "1" ]]; then
+          if [[ "$PR_COUNT" -ne 1 ]]; then
             echo "::error::Expected exactly one open hovmester sync PR, found $PR_COUNT"
             exit 1
           fi
 
-          PR_NUMBER=$(gh api "repos/${REPO}/pulls?state=open&head=${OWNER}:${EXPECTED_BRANCH}&base=${DEFAULT_BRANCH}" --jq '.[0].number')
+          PR_NUMBER=$(printf '%s\n' "$PR_NUMBERS" | sed -n '1p')
           PR_AUTHOR=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.user.login')
           HEAD_REF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.ref')
           HEAD_REPO=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')
@@ -153,6 +156,8 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: "2906300"
+          permission-contents: write
+          permission-pull-requests: write
           private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
 
       - name: Enable auto-merge

--- a/.github/workflows/hovmester-automerge.yml
+++ b/.github/workflows/hovmester-automerge.yml
@@ -1,0 +1,166 @@
+name: Automerge hovmester sync
+
+on:
+  workflow_run:
+    workflows: ["Verify hovmester sync"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  automerge-hovmester-sync:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Re-verify sync PR
+        id: verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_BRANCH: "hovmester-sync"
+          EXPECTED_PR_AUTHOR: "teamesyfo-automerge[bot]"
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          OWNER="${REPO%%/*}"
+
+          RUN_EVENT=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.event')
+          RUN_CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.conclusion')
+          RUN_HEAD_BRANCH=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_branch')
+          RUN_HEAD_SHA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_sha')
+          RUN_HEAD_REPO=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_repository.full_name')
+
+          if [[ "$RUN_CONCLUSION" != "success" ]]; then
+            echo "::error::Unexpected workflow conclusion: $RUN_CONCLUSION"
+            exit 1
+          fi
+
+          if [[ "$RUN_EVENT" != "pull_request" ]]; then
+            echo "Workflow run event is $RUN_EVENT - skipping automerge"
+            exit 0
+          fi
+
+          if [[ "$RUN_HEAD_BRANCH" != "$EXPECTED_BRANCH" ]]; then
+            echo "Workflow run branch is $RUN_HEAD_BRANCH - skipping automerge"
+            exit 0
+          fi
+
+          if [[ "$RUN_HEAD_REPO" != "$REPO" ]]; then
+            echo "::error::Unexpected workflow head repository: $RUN_HEAD_REPO"
+            exit 1
+          fi
+
+          PR_COUNT=$(gh api "repos/${REPO}/pulls?state=open&head=${OWNER}:${EXPECTED_BRANCH}&base=${DEFAULT_BRANCH}" --jq 'length')
+
+          if [[ "$PR_COUNT" == "0" ]]; then
+            echo "No open hovmester sync PR found - skipping automerge"
+            exit 0
+          fi
+
+          if [[ "$PR_COUNT" != "1" ]]; then
+            echo "::error::Expected exactly one open hovmester sync PR, found $PR_COUNT"
+            exit 1
+          fi
+
+          PR_NUMBER=$(gh api "repos/${REPO}/pulls?state=open&head=${OWNER}:${EXPECTED_BRANCH}&base=${DEFAULT_BRANCH}" --jq '.[0].number')
+          PR_AUTHOR=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.user.login')
+          HEAD_REF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.ref')
+          HEAD_REPO=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')
+          HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
+
+          if [[ "$PR_AUTHOR" != "$EXPECTED_PR_AUTHOR" ]]; then
+            echo "::error::Unexpected PR author: $PR_AUTHOR"
+            echo "Expected PR author: $EXPECTED_PR_AUTHOR"
+            exit 1
+          fi
+
+          if [[ "$HEAD_REF" != "$EXPECTED_BRANCH" ]]; then
+            echo "::error::Unexpected PR branch: $HEAD_REF"
+            echo "Expected PR branch: $EXPECTED_BRANCH"
+            exit 1
+          fi
+
+          if [[ "$HEAD_REPO" != "$REPO" ]]; then
+            echo "::error::Unexpected PR head repository: $HEAD_REPO"
+            exit 1
+          fi
+
+          if [[ "$HEAD_SHA" != "$RUN_HEAD_SHA" ]]; then
+            echo "::error::Head SHA mismatch between verify run and PR"
+            echo "Workflow run head SHA: $RUN_HEAD_SHA"
+            echo "Pull request head SHA: $HEAD_SHA"
+            exit 1
+          fi
+
+          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --paginate --jq '.[] | .filename, (.previous_filename // empty)')
+
+          if [[ -z "$FILES" ]]; then
+            echo "::error::No files found from pull request files API; failing closed"
+            exit 1
+          fi
+
+          echo "Changed files:"
+          echo "$FILES"
+
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+
+            if [[ "$file" == .github/workflows/* ]]; then
+              echo "::error::Workflow changes are not allowed in hovmester sync PRs: $file"
+              exit 1
+            fi
+
+            case "$file" in
+              .github/agents/*|\
+              .github/instructions/*|\
+              .github/skills/*|\
+              .github/ISSUE_TEMPLATE/*|\
+              .github/PULL_REQUEST_TEMPLATE.md|\
+              .github/.hovmester-manifest.json|\
+              .github/.copilot-kitchen-manifest.json)
+                ;;
+              *)
+                echo "::error::File outside sync scope: $file"
+                echo "Only hovmester-managed paths are allowed in sync PRs"
+                exit 1
+                ;;
+            esac
+          done <<< "$FILES"
+
+          echo "✅ Sync PR re-verified"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Approve sync PR
+        if: steps.verify.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.verify.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "Auto-approved after workflow_run re-verification ✅"
+
+      - name: Create GitHub App token for merge
+        if: steps.verify.outputs.pr_number != ''
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: "2906300"
+          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
+
+      - name: Enable auto-merge
+        if: steps.verify.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_SHA: ${{ steps.verify.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.verify.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash --match-head-commit "$HEAD_SHA"

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -11,7 +11,6 @@ permissions:
 
 jobs:
   verify-hovmester-sync:
-    if: github.event_name == 'merge_group' || (github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -5,12 +5,11 @@ on:
     types: [opened, synchronize, reopened]
   merge_group:
 
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
   verify-hovmester-sync:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -28,7 +28,7 @@ jobs:
           set -euo pipefail
 
           if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
-            echo "✅ Merge queue - verification already completed on pull_request"
+            echo "✅ Merge queue required check is intentionally a no-op for merge_group"
             exit 0
           fi
 

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -1,18 +1,19 @@
-name: Verify and merge hovmester sync
+name: Verify hovmester sync
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
   merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   verify-hovmester-sync:
     if: github.event_name == 'merge_group' || (github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Verify file scope
         env:
@@ -27,7 +28,7 @@ jobs:
           set -euo pipefail
 
           if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
-            echo "✅ Merge queue — verification already completed on pull_request_target"
+            echo "✅ Merge queue - verification already completed on pull_request"
             exit 0
           fi
 
@@ -55,6 +56,12 @@ jobs:
 
           while IFS= read -r file; do
             [[ -z "$file" ]] && continue
+
+            if [[ "$file" == .github/workflows/* ]]; then
+              echo "::error::Workflow changes are not allowed in hovmester sync PRs: $file"
+              exit 1
+            fi
+
             case "$file" in
               .github/agents/*|\
               .github/instructions/*|\
@@ -73,29 +80,3 @@ jobs:
           done <<< "$FILES"
 
           echo "✅ All files within hovmester sync scope"
-
-      - name: Create GitHub App token for merge
-        if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'teamesyfo-automerge[bot]'
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          app-id: "2906300"
-          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
-
-      - name: Approve sync PR
-        if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'teamesyfo-automerge[bot]'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "Auto-approved: file scope verified ✅"
-
-      - name: Enable auto-merge
-        if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'teamesyfo-automerge[bot]'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -1,18 +1,19 @@
-name: Verify and merge hovmester sync
+name: Verify hovmester sync
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
   merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   verify-hovmester-sync:
     if: github.event_name == 'merge_group' || (github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Verify file scope
         env:
@@ -27,7 +28,7 @@ jobs:
           set -euo pipefail
 
           if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
-            echo "✅ Merge queue — verification already completed on pull_request_target"
+            echo "✅ Merge queue - verification already completed on pull_request"
             exit 0
           fi
 
@@ -55,6 +56,12 @@ jobs:
 
           while IFS= read -r file; do
             [[ -z "$file" ]] && continue
+
+            if [[ "$file" == .github/workflows/* ]]; then
+              echo "::error::Workflow changes are not allowed in hovmester sync PRs: $file"
+              exit 1
+            fi
+
             case "$file" in
               .github/agents/*|\
               .github/instructions/*|\
@@ -73,29 +80,3 @@ jobs:
           done <<< "$FILES"
 
           echo "✅ All files within hovmester sync scope"
-
-      - name: Create GitHub App token for merge
-        if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'teamesyfo-automerge[bot]'
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: "2906300"
-          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
-
-      - name: Approve sync PR
-        if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'teamesyfo-automerge[bot]'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "Auto-approved: file scope verified ✅"
-
-      - name: Enable auto-merge
-        if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'teamesyfo-automerge[bot]'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash


### PR DESCRIPTION
## Beskrivelse

Deler Hovmester-flyten i en read-only verify-workflow på `pull_request`/`merge_group` og en egen automerge-workflow på `workflow_run`. Første PR må sannsynligvis merges manuelt før den nye `workflow_run`-baserte automerge-flyten kan testes fra default branch. Repoet bruker merge queue, og `verify-hovmester-sync` blir stående som required check.

## Endringer

- `.github/workflows/hovmester-verify.yml`: bytter fra `pull_request_target` til `pull_request`, gjør workflowen read-only og lar den kun verifisere Hovmester-forvaltede filer
- `.github/workflows/hovmester-automerge.yml`: legger til egen `workflow_run`-styrt automerge som re-verifiserer PR, godkjenner med `GITHUB_TOKEN` og setter auto-merge med GitHub App-token og head-SHA-binding

## Issue

Ingen egen issue. Dette er en sikkerhets- og driftsendring for å migrere Hovmester-flyten bort fra `pull_request_target`.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)