### PR TITLE
fix(demo): migrate to new aksel tokens to restore demo button

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,15 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!node_modules", "!.next", "!dist", "!build"]
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build",
+      "!.github/skills/**/scripts",
+      "!.github/skills/**/references"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
+++ b/src/components/DemoScenarioPicker/DemoScenarioPicker.tsx
@@ -55,8 +55,8 @@ export function DemoScenarioPicker({
       <Box
         position="fixed"
         style={{
-          bottom: "var(--a-spacing-6)",
-          right: "var(--a-spacing-6)",
+          bottom: "var(--ax-space-24)",
+          right: "var(--ax-space-24)",
           zIndex: 100,
         }}
       >

--- a/src/components/DemoScenarioPicker/__tests__/DemoScenarioPicker.test.tsx
+++ b/src/components/DemoScenarioPicker/__tests__/DemoScenarioPicker.test.tsx
@@ -174,11 +174,11 @@ describe("DemoScenarioPicker", () => {
       mockEnv.isLocalOrDemo = false;
 
       render(
-        <>
+        <div>
           {isLocalOrDemo && (
             <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />
           )}
-        </>,
+        </div>,
       );
 
       expect(
@@ -190,11 +190,11 @@ describe("DemoScenarioPicker", () => {
       mockEnv.isLocalOrDemo = true;
 
       render(
-        <>
+        <div>
           {isLocalOrDemo && (
             <DemoScenarioPicker scenarios={AG_SCENARIO_OPTIONS} />
           )}
-        </>,
+        </div>,
       );
 
       expect(screen.getByRole("button", { name: /demo/i })).toBeInTheDocument();

--- a/src/utils/planUtils.ts
+++ b/src/utils/planUtils.ts
@@ -5,8 +5,5 @@ export function hasMedvirket(content: FormSnapshot): boolean {
     .flatMap((s) => s.fields)
     .find((f) => f.fieldId === "harDenAnsatteMedvirket");
 
-  if (!field || field.fieldType !== "RADIO_GROUP") {
-    return false;
-  }
-  return field.selectedOptionId === "ja";
+  return field?.fieldType === "RADIO_GROUP" && field.selectedOptionId === "ja";
 }


### PR DESCRIPTION
## Beskrivelse

Fikser demo-knappen som sluttet å fungere etter Aksel v3-oppgradering.
Årsak: `--a-spacing-6` er ikke lenger definert i Aksel v3, byttet til tilsvarende `--ax-space-24`.

## Endringer

- `DemoScenarioPicker.tsx`: `--a-spacing-6` -> `--ax-space-24` (fikser posisjonering av demo-knapp)
- `DemoScenarioPicker.test.tsx`: Wrapper `<>` -> `<div>`
- `planUtils.ts`: Forenkler logikk med optional chaining
- `biome.json`: Eksluderer skill-scripts fra linting/formattering

## Issue

Closes #818

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
