### PR TITLE
fix(aktiv-plan): endre tekst på knapp og modal for planoppdatering

### DIFF
--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/Buttons/AktivPlanButtons.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/Buttons/AktivPlanButtons.tsx
@@ -26,7 +26,7 @@ export function AktivPlanButtons({ planId, hasUtkast }: Props) {
           onClick={() => lagNyPlanModalRef.current?.showModal()}
           tracking={knappKlikket.aktivPlanSide.lagNyOppfolgingsplanModalTrigger}
         >
-          Lag ny oppfølgingsplan
+          Oppdater planen
         </TrackedButton>
 
         <VisPdfButtonAG narmesteLederId={narmesteLederId} planId={planId} />

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/Buttons/__tests__/AktivPlanButtons.test.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/Buttons/__tests__/AktivPlanButtons.test.tsx
@@ -34,7 +34,7 @@ describe("AktivPlanButtons", () => {
     render(<AktivPlanButtons planId="plan-123" hasUtkast={false} />);
 
     expect(
-      screen.getByRole("button", { name: /Lag ny oppfølgingsplan/i }),
+      screen.getByRole("button", { name: /Oppdater planen/i }),
     ).toBeInTheDocument();
   });
 

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/LagNyPlanModal.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/LagNyPlanModal.tsx
@@ -60,7 +60,7 @@ export function LagNyPlanModal({ ref, hasUtkast }: Props) {
     <Modal
       ref={ref}
       header={{
-        heading: "Lag ny oppfølgingsplan",
+        heading: "Oppdater planen",
       }}
       closeOnBackdropClick={!isPending}
       onBeforeClose={() => !isPending}

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/__tests__/LagNyPlanModal.test.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/__tests__/LagNyPlanModal.test.tsx
@@ -78,7 +78,7 @@ describe("LagNyPlanModal", () => {
     render(<LagNyPlanModal ref={{ current: null }} hasUtkast={false} />);
 
     expect(
-      screen.getByRole("heading", { name: /Lag ny oppfølgingsplan/i }),
+      screen.getByRole("heading", { name: /Oppdater planen/i }),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Beskrivelse

Endrer tekster i aktiv plan-flyten slik at det er tydeligere at brukeren oppdaterer en eksisterende plan.

Verifisert med `pnpm run build`, `pnpm run lint` og `pnpm run test -- --run src/components/FerdigstiltPlanSider/AktivPlanSide/Buttons/__tests__/AktivPlanButtons.test.tsx src/components/FerdigstiltPlanSider/AktivPlanSide/__tests__/LagNyPlanModal.test.tsx`.

## Endringer

- `AktivPlanButtons`: endrer knappeteksten fra `Lag ny oppfølgingsplan` til `Oppdater planen`
- `LagNyPlanModal`: endrer modaloverskriften til `Oppdater planen`
- Oppdaterer testene for knapp og modal til ny tekst

## Issue

Relates to navikt/team-esyfo#152

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)