### PR TITLE
feat(oppfolgingsplan): vis dato for deling i statustagger

### DIFF
--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/DelAktivPlanMedLegeEllerNav.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/DelAktivPlanMedLegeEllerNav.tsx
@@ -106,6 +106,12 @@ function DelAktivPlanMedLegeEllerNav({ planId }: Props) {
     if (sendToVeileder) delMedVeilederAction({ planId });
   };
 
+  // Når planen er sendt til både fastlege og Nav-veileder, er delingsboksen
+  // ikke lenger relevant. Delingsstatusen vises da i taggene øverst på siden.
+  if (!hasUnsentRecipients) {
+    return null;
+  }
+
   return (
     <Box
       background="info-soft"
@@ -160,7 +166,11 @@ function DelAktivPlanMedLegeEllerNav({ planId }: Props) {
 
         {validationError && (
           <ErrorSummary heading="Feil ved sending av plan" className="my-4">
-            <ErrorSummary.Item href="#fastlege-checkbox">
+            <ErrorSummary.Item
+              href={
+                sentToFastlege ? "#veileder-checkbox" : "#fastlege-checkbox"
+              }
+            >
               {validationError}
             </ErrorSummary.Item>
           </ErrorSummary>

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/__tests__/DelAktivPlanMedLegeEllerNav.test.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/DelAktivPlan/__tests__/DelAktivPlanMedLegeEllerNav.test.tsx
@@ -92,12 +92,33 @@ describe("DelAktivPlanMedLegeEllerNav", () => {
       ).toBeInTheDocument();
     });
 
-    test("does not render send button when all recipients have received plan", () => {
+    test("shows the sharing box when only one recipient has received the plan", () => {
+      renderComponent("2026-01-15T10:00:00Z", null);
+
+      expect(
+        screen.getByRole("heading", {
+          name: /hvem vil du sende planen til/i,
+          level: 2,
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /send planen/i }),
+      ).toBeInTheDocument();
+    });
+
+    test("hides the whole sharing box when all recipients have received plan", () => {
       renderComponent("2026-01-15T10:00:00Z", "2026-01-15T11:00:00Z");
 
       expect(
+        screen.queryByRole("heading", {
+          name: /hvem vil du sende planen til/i,
+        }),
+      ).not.toBeInTheDocument();
+      expect(
         screen.queryByRole("button", { name: /send planen/i }),
       ).not.toBeInTheDocument();
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+      expect(screen.queryByText(/sendt til fastlege/i)).not.toBeInTheDocument();
     });
   });
 
@@ -128,11 +149,13 @@ describe("DelAktivPlanMedLegeEllerNav", () => {
       ).toBeInTheDocument();
     });
 
-    test("shows both success messages when sent to both recipients", () => {
-      renderComponent("2026-01-15T10:00:00Z", "2026-01-15T11:00:00Z");
+    test("keeps the checkbox for the recipient that has not received the plan", () => {
+      renderComponent("2026-01-15T10:00:00Z", null);
 
       expect(screen.getByText(/sendt til fastlege/i)).toBeInTheDocument();
-      expect(screen.getByText(/sendt til nav-veileder/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("checkbox", { name: /nav-veileder/i }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -257,6 +280,30 @@ describe("DelAktivPlanMedLegeEllerNav", () => {
         );
       });
     });
+
+    test("hides the sharing box without reload when the last recipient receives the plan", async () => {
+      const user = userEvent.setup();
+      delMedVeilederSpy.mockResolvedValue({
+        deltMedVeilederTidspunkt: "2026-01-16T11:00:00Z",
+        errorDelMedVeileder: null,
+      });
+
+      renderComponent("2026-01-15T10:00:00Z", null);
+
+      const veilederCheckbox = screen.getByRole("checkbox", {
+        name: /nav-veileder/i,
+      });
+      await user.click(veilederCheckbox);
+      await user.click(screen.getByRole("button", { name: /send planen/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("heading", {
+            name: /hvem vil du sende planen til/i,
+          }),
+        ).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe("Accessibility", () => {
@@ -275,10 +322,10 @@ describe("DelAktivPlanMedLegeEllerNav", () => {
     });
 
     test("success messages have proper role", () => {
-      renderComponent("2026-01-15T10:00:00Z", "2026-01-15T11:00:00Z");
+      renderComponent("2026-01-15T10:00:00Z", null);
 
       const successMessages = screen.getAllByRole("status");
-      expect(successMessages).toHaveLength(2);
+      expect(successMessages).toHaveLength(1);
     });
 
     test("error summary has proper heading", async () => {

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/HeadingAndTags/AktivPlanTopTags.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/HeadingAndTags/AktivPlanTopTags.tsx
@@ -12,11 +12,13 @@ export function AktivPlanTopTags() {
   const isDeltMedVeileder = Boolean(deltMedVeilederTidspunkt);
 
   return (
-    <HStack gap="space-8">
+    <HStack gap="space-8" aria-live="polite">
       <PlanDelingStatusTags
         tagSize="small"
         isDeltMedLege={isDeltMedLege}
         isDeltMedVeileder={isDeltMedVeileder}
+        deltMedLegeTidspunkt={deltMedLegeTidspunkt}
+        deltMedVeilederTidspunkt={deltMedVeilederTidspunkt}
       />
     </HStack>
   );

--- a/src/components/FerdigstiltPlanSider/AktivPlanSide/HeadingAndTags/__tests__/AktivPlanTopTags.test.tsx
+++ b/src/components/FerdigstiltPlanSider/AktivPlanSide/HeadingAndTags/__tests__/AktivPlanTopTags.test.tsx
@@ -1,0 +1,117 @@
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useParams } from "next/navigation";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import PlanDelingStatusTags from "@/components/OversiktSide/PlanListe/PlanLinkCard/PlanLinkCardFooterTags";
+import * as delPlanMedVeilederModule from "@/server/actions/delPlanMedVeileder";
+import { render } from "@/test/test-utils";
+import DelAktivPlanMedLegeEllerNav from "../../DelAktivPlan/DelAktivPlanMedLegeEllerNav";
+import { PlanDelingProvider } from "../../PlanDelingContext";
+import { AktivPlanTopTags } from "../AktivPlanTopTags";
+
+const MOCK_PLAN_ID = "test-plan-123";
+const MOCK_LEDER_ID = "test-leder-123";
+
+// Datoformatet skjuler året når delingen skjedde inneværende år, derfor er
+// årstallet valgfritt i regexene under.
+const SENDT_TIL_FASTLEGE_MED_DATO = /^Sendt til fastlege 15\. januar( \d{4})?$/;
+const SENDT_TIL_NAV_MED_DATO = /^Sendt til Nav 3\. februar( \d{4})?$/;
+
+vi.mock("next/navigation", async () => {
+  const { mockNextNavigation } = await import(
+    "@/test/mocks/nextNavigationMock"
+  );
+
+  return mockNextNavigation();
+});
+
+describe("AktivPlanTopTags", () => {
+  beforeEach(() => {
+    vi.mocked(useParams).mockReturnValue({ narmesteLederId: MOCK_LEDER_ID });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderTopTags(
+    initialDeltMedLegeTidspunkt: string | null = null,
+    initialDeltMedVeilederTidspunkt: string | null = null,
+  ) {
+    return render(
+      <PlanDelingProvider
+        initialDeltMedLegeTidspunkt={initialDeltMedLegeTidspunkt}
+        initialDeltMedVeilederTidspunkt={initialDeltMedVeilederTidspunkt}
+      >
+        <AktivPlanTopTags />
+      </PlanDelingProvider>,
+    );
+  }
+
+  test("viser dato for deling med både fastlege og Nav", () => {
+    renderTopTags("2026-01-15T10:00:00Z", "2026-02-03T11:00:00Z");
+
+    expect(screen.getByText(SENDT_TIL_FASTLEGE_MED_DATO)).toBeInTheDocument();
+    expect(screen.getByText(SENDT_TIL_NAV_MED_DATO)).toBeInTheDocument();
+  });
+
+  test("viser dato kun for mottakeren som har fått planen", () => {
+    renderTopTags("2026-01-15T10:00:00Z", null);
+
+    expect(screen.getByText(SENDT_TIL_FASTLEGE_MED_DATO)).toBeInTheDocument();
+    expect(screen.getByText("Ikke sendt til Nav")).toBeInTheDocument();
+  });
+
+  test("viser status uten dato når planen ikke er delt", () => {
+    renderTopTags();
+
+    expect(screen.getByText("Ikke sendt til fastlege")).toBeInTheDocument();
+    expect(screen.getByText("Ikke sendt til Nav")).toBeInTheDocument();
+  });
+
+  test("oppdaterer taggen med dato etter vellykket deling, uten sideoppdatering", async () => {
+    const user = userEvent.setup();
+    const delMedVeilederSpy = vi
+      .spyOn(delPlanMedVeilederModule, "delPlanMedVeilederServerAction")
+      .mockResolvedValue({
+        deltMedVeilederTidspunkt: "2026-02-03T11:00:00Z",
+        errorDelMedVeileder: null,
+      });
+
+    render(
+      <PlanDelingProvider
+        initialDeltMedLegeTidspunkt="2026-01-15T10:00:00Z"
+        initialDeltMedVeilederTidspunkt={null}
+      >
+        <AktivPlanTopTags />
+        <DelAktivPlanMedLegeEllerNav planId={MOCK_PLAN_ID} />
+      </PlanDelingProvider>,
+    );
+
+    expect(screen.getByText("Ikke sendt til Nav")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: /nav-veileder/i }));
+    await user.click(screen.getByRole("button", { name: /send planen/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(SENDT_TIL_NAV_MED_DATO)).toBeInTheDocument();
+    });
+
+    delMedVeilederSpy.mockRestore();
+  });
+});
+
+describe("PlanDelingStatusTags uten delingstidspunkt", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("viser ikke dato når tidspunkt ikke sendes inn, slik som i oversikten", () => {
+    render(
+      <PlanDelingStatusTags tagSize="small" isDeltMedLege isDeltMedVeileder />,
+    );
+
+    expect(screen.getByText("Sendt til fastlege")).toBeInTheDocument();
+    expect(screen.getByText("Sendt til Nav")).toBeInTheDocument();
+  });
+});

--- a/src/components/OversiktSide/PlanListe/PlanLinkCard/PlanLinkCardFooterTags.tsx
+++ b/src/components/OversiktSide/PlanListe/PlanLinkCard/PlanLinkCardFooterTags.tsx
@@ -1,16 +1,27 @@
 import { Tag, type TagProps } from "@navikt/ds-react";
+import { getFormattedDateString } from "@/ui-helpers/dateAndTime";
 
 interface Props {
   tagSize: TagProps["size"];
   isDeltMedLege: boolean;
   isDeltMedVeileder: boolean;
+  /** Settes kun der delingsdatoen skal vises i taggen, for eksempel på aktiv plan. */
+  deltMedLegeTidspunkt?: string | null;
+  /** Settes kun der delingsdatoen skal vises i taggen, for eksempel på aktiv plan. */
+  deltMedVeilederTidspunkt?: string | null;
   tagVariantHvisDelt?: TagProps["variant"];
   tagVariantHvisIkkeDelt?: TagProps["variant"];
+}
+
+function medDelingsdato(tekst: string, tidspunkt?: string | null) {
+  return tidspunkt ? `${tekst} ${getFormattedDateString(tidspunkt)}` : tekst;
 }
 
 export default function PlanDelingStatusTags({
   isDeltMedLege,
   isDeltMedVeileder,
+  deltMedLegeTidspunkt,
+  deltMedVeilederTidspunkt,
   tagVariantHvisDelt = "success-moderate",
   tagVariantHvisIkkeDelt = "neutral-moderate",
   tagSize: size,
@@ -22,7 +33,7 @@ export default function PlanDelingStatusTags({
       </Tag>
       {isDeltMedLege ? (
         <Tag variant={tagVariantHvisDelt} size={size}>
-          Sendt til fastlege
+          {medDelingsdato("Sendt til fastlege", deltMedLegeTidspunkt)}
         </Tag>
       ) : (
         <Tag variant={tagVariantHvisIkkeDelt} size={size}>
@@ -31,7 +42,7 @@ export default function PlanDelingStatusTags({
       )}
       {isDeltMedVeileder ? (
         <Tag variant={tagVariantHvisDelt} size={size}>
-          Sendt til Nav
+          {medDelingsdato("Sendt til Nav", deltMedVeilederTidspunkt)}
         </Tag>
       ) : (
         <Tag variant={tagVariantHvisIkkeDelt} size={size}>


### PR DESCRIPTION
## Beskrivelse

Viser delingsstatus tydeligere for aktive oppfølgingsplaner. Delingsboksen skjules når planen er sendt til både fastlege og Nav, og de aktive plantaggene viser datoen planen ble delt. På forsiden vises de eksisterende taggene fortsatt uten dato.

## Endringer

- `DelAktivPlanMedLegeEllerNav`: Skjuler delingsboksen når begge mottakere har mottatt planen.
- `AktivPlanTopTags` og delingstaggene: Viser delingsdato i tagger på aktiv plan, men beholder dato-frie tagger i oversikten.
- Tester: Dekker skjuling av delingsboks og visning/oppdatering av delingsdatoer.

## Issue

Closes navikt/team-esyfo#152

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Verifisering

- `git diff --check`
- 2 Vitest-filer / 23 tester
- `pnpm run build`

Ekstra kryssmodell-review ble valgt bort av brukeren.