### PR TITLE
fix(oversikt): fjern utdaterte forsidetekster

### DIFF
--- a/src/app/[narmesteLederId]/page.tsx
+++ b/src/app/[narmesteLederId]/page.tsx
@@ -1,11 +1,4 @@
-import { PlantIcon } from "@navikt/aksel-icons";
 import { BodyLong, Heading } from "@navikt/ds-react";
-import {
-  InfoCard,
-  InfoCardContent,
-  InfoCardHeader,
-  InfoCardTitle,
-} from "@navikt/ds-react/InfoCard";
 import { Suspense } from "react";
 import TextContentBox from "@/components/layout/TextContentBox";
 import { AnsattIkkeSykmeldtAlert } from "@/components/OversiktSide/AnsattIkkeSykmeldtAlert.tsx";
@@ -24,16 +17,6 @@ export default async function OversiktPageForAG({
       <Heading level="2" size="xlarge" spacing>
         Oppfølgingsplaner
       </Heading>
-
-      <InfoCard data-color="info" className={"mb-8"}>
-        <InfoCardHeader icon={<PlantIcon aria-hidden />}>
-          <InfoCardTitle as="h3">Ny oppfølgingsplan!</InfoCardTitle>
-        </InfoCardHeader>
-        <InfoCardContent>
-          Vi har laget en ny versjon av oppfølgingsplan-tjenesten. Håper du
-          liker den!
-        </InfoCardContent>
-      </InfoCard>
 
       <TextContentBox>
         <BodyLong size="large" spacing>

--- a/src/app/sykmeldt/page.tsx
+++ b/src/app/sykmeldt/page.tsx
@@ -1,11 +1,4 @@
-import { PlantIcon } from "@navikt/aksel-icons";
 import { BodyLong, Heading } from "@navikt/ds-react";
-import {
-  InfoCard,
-  InfoCardContent,
-  InfoCardHeader,
-  InfoCardTitle,
-} from "@navikt/ds-react/InfoCard";
 import { Suspense } from "react";
 import TextContentBox from "@/components/layout/TextContentBox.tsx";
 import PlanListeForSykmeldt from "@/components/OversiktSide/PlanListe/PlanListeForSykmeldt.tsx";
@@ -17,16 +10,6 @@ export default async function OversiktPageForSM(_: PageProps<"/sykmeldt">) {
       <Heading level="2" size="xlarge" spacing>
         Oppfølgingsplaner
       </Heading>
-
-      <InfoCard data-color="info" className={"mb-8"}>
-        <InfoCardHeader icon={<PlantIcon aria-hidden />}>
-          <InfoCardTitle as="h3">Ny oppfølgingsplan!</InfoCardTitle>
-        </InfoCardHeader>
-        <InfoCardContent>
-          Vi har laget en ny versjon av oppfølgingsplan-tjenesten. Håper du
-          liker den!
-        </InfoCardContent>
-      </InfoCard>
 
       <TextContentBox>
         <BodyLong size="large" className="mb-4">

--- a/src/components/OversiktSide/PlanListe/PlanListeForArbeidsgiver.tsx
+++ b/src/components/OversiktSide/PlanListe/PlanListeForArbeidsgiver.tsx
@@ -81,8 +81,7 @@ export default async function PlanListeForArbeidsgiver({
       {aktivPlan && (
         <InlineMessage status="info" className="mt-4">
           Aktive og tidligere oppfølgingsplaner blir utilgjengelige når den
-          ansatte ikke har hatt sykmelding hos dere på 6 måneder. Åpne planen og
-          velg «Vis PDF» for å lagre en kopi.
+          ansatte ikke har hatt sykmelding hos dere på 6 måneder.
         </InlineMessage>
       )}
     </section>

--- a/src/components/OversiktSide/PlanListe/__tests__/PlanListeForArbeidsgiver.test.tsx
+++ b/src/components/OversiktSide/PlanListe/__tests__/PlanListeForArbeidsgiver.test.tsx
@@ -325,17 +325,6 @@ describe("PlanListeForArbeidsgiver", () => {
     ).not.toBeInTheDocument();
   });
 
-  test("does not display the «Vis PDF»-copy hint in the 6-month AG text", async () => {
-    mockFetch.mockResolvedValue({
-      error: null,
-      data: mockOversiktDataMedPlanerForAG,
-    });
-
-    await renderAsync(PlanListeForArbeidsgiver({ narmesteLederId: "12345" }));
-
-    expect(screen.queryByText(/for å lagre en kopi/)).not.toBeInTheDocument();
-  });
-
   test("6-month info message renders after plan cards, not before", async () => {
     mockFetch.mockResolvedValue({
       error: null,

--- a/src/components/OversiktSide/PlanListe/__tests__/PlanListeForArbeidsgiver.test.tsx
+++ b/src/components/OversiktSide/PlanListe/__tests__/PlanListeForArbeidsgiver.test.tsx
@@ -325,6 +325,17 @@ describe("PlanListeForArbeidsgiver", () => {
     ).not.toBeInTheDocument();
   });
 
+  test("does not display the «Vis PDF»-copy hint in the 6-month AG text", async () => {
+    mockFetch.mockResolvedValue({
+      error: null,
+      data: mockOversiktDataMedPlanerForAG,
+    });
+
+    await renderAsync(PlanListeForArbeidsgiver({ narmesteLederId: "12345" }));
+
+    expect(screen.queryByText(/for å lagre en kopi/)).not.toBeInTheDocument();
+  });
+
   test("6-month info message renders after plan cards, not before", async () => {
     mockFetch.mockResolvedValue({
       error: null,


### PR DESCRIPTION
## Beskrivelse

Fjerner utdaterte tekster fra forsidene til oppfølgingsplanen. «Ny oppfølgingsplan»-boksen fjernes for både arbeidsgiver og arbeidstaker, og arbeidsgiver oppfordres ikke lenger til å lagre en lokal PDF-kopi.

## Endringer

- Fjernet «Ny oppfølgingsplan»-boksen på arbeidsgiverforsiden
- Fjernet «Ny oppfølgingsplan»-boksen på arbeidstakerforsiden
- Fjernet PDF-oppfordringen under tidligere planer for arbeidsgiver
- Oppdatert regresjonstest for arbeidsgiverteksten

## Issue

Closes #950

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet manuelt og automatisk
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)