### PR TITLE
perf(oversikt): dedupliser AG-oversiktsfetchen med React cache()

### DIFF
--- a/src/app/[narmesteLederId]/layout.tsx
+++ b/src/app/[narmesteLederId]/layout.tsx
@@ -23,10 +23,11 @@ export default async function RootLayoutForAG({
 }: LayoutProps<"/[narmesteLederId]">) {
   const { narmesteLederId } = await params;
 
-  // This fetch is also done in server components for the oversikt page, so when
-  // visiting the oversikt page first, all these fetch calls made from different
-  // server components (this component included) will be deduplicated by
-  // Next.js.
+  // This fetch is also done in server components for the oversikt page. The
+  // function is wrapped in React cache(), so all calls made from different
+  // server components (this component included) during the same render pass
+  // share one backend request. (Next.js' own fetch memoization does not apply
+  // here, since every request gets a unique Nav-Call-Id header.)
   const oversiktResult =
     await fetchOppfolgingsplanOversiktForAG(narmesteLederId);
 

--- a/src/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt.ts
+++ b/src/server/fetchData/arbeidsgiver/fetchOppfolgingsplanOversikt.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { getEndpointOversiktForAG } from "@/common/backend-endpoints";
 import {
   DEMO_SCENARIO_COOKIE,
@@ -41,26 +42,34 @@ export function getMockDataForScenario(scenario: DemoScenario) {
   }
 }
 
-export async function fetchOppfolgingsplanOversiktForAG(
-  narmesteLederId: string,
-): Promise<FetchGetResult<OppfolgingsplanerOversiktForAG>> {
-  if (isLocalOrDemo) {
-    const { cookies } = await import("next/headers");
-    const scenario = parseDemoScenario(
-      (await cookies()).get(DEMO_SCENARIO_COOKIE)?.value,
-    );
-    await simulateBackendDelay();
+/**
+ * Cached with React cache() so all server components that need the oversikt in
+ * the same render pass share one backend call. Next.js' own fetch memoization
+ * does not dedupe these requests: the cache key includes all request headers,
+ * and getBackendRequestHeaders() sets a fresh nanoid() in Nav-Call-Id per call.
+ */
+export const fetchOppfolgingsplanOversiktForAG = cache(
+  async (
+    narmesteLederId: string,
+  ): Promise<FetchGetResult<OppfolgingsplanerOversiktForAG>> => {
+    if (isLocalOrDemo) {
+      const { cookies } = await import("next/headers");
+      const scenario = parseDemoScenario(
+        (await cookies()).get(DEMO_SCENARIO_COOKIE)?.value,
+      );
+      await simulateBackendDelay();
 
-    return {
-      error: null,
-      data: getMockDataForScenario(scenario),
-    };
-  }
+      return {
+        error: null,
+        data: getMockDataForScenario(scenario),
+      };
+    }
 
-  return await tokenXFetchGetWithResult({
-    targetApi: TokenXTargetApi.SYFO_OPPFOLGINGSPLAN_BACKEND,
-    endpoint: getEndpointOversiktForAG(narmesteLederId),
-    responseDataSchema: OppfolgingsplanerOversiktResponseSchemaForAG,
-    redirectAfterLoginUrl: getRedirectAfterLoginUrlForAG(narmesteLederId),
-  });
-}
+    return await tokenXFetchGetWithResult({
+      targetApi: TokenXTargetApi.SYFO_OPPFOLGINGSPLAN_BACKEND,
+      endpoint: getEndpointOversiktForAG(narmesteLederId),
+      responseDataSchema: OppfolgingsplanerOversiktResponseSchemaForAG,
+      redirectAfterLoginUrl: getRedirectAfterLoginUrlForAG(narmesteLederId),
+    });
+  },
+);


### PR DESCRIPTION
## Hva

Wrapper `fetchOppfolgingsplanOversiktForAG` i React `cache()` (samme mønster som allerede brukes i `tokenXExchange.ts` og `idPortenToken.ts`), slik at alle server-komponenter som trenger oversikten i samme render-pass deler ett backend-kall. Oppdaterer også kommentaren i `layout.tsx` som beskrev dedupe-mekanismen feil.

## Hvorfor

Kommentaren i `layout.tsx` antok at Next.js deduper de identiske oversiktskallene fra layout, `AnsattIkkeSykmeldtAlert`, `NyPlanButtonHvisTomListe` og `PlanListeForArbeidsgiver`. Det stemmer ikke i praksis: Next sin request-memoization (`next/dist/server/lib/dedupe-fetch.js`) nøkler på **alle** request-headere (kun `traceparent`/`tracestate` er unntatt), og `getBackendRequestHeaders()` setter en fersk `nanoid()` i `Nav-Call-Id` per kall. Hver sidevisning av AG-oversikten gjorde derfor **fire reelle backend-kall** for samme `narmesteLederId`.

## Verifisering

Målt empirisk med en minimal Next 16.2.12-app (production build) mot en teller-server, én sidevisning:

| Scenario | fetch-kall | Reelle HTTP-treff |
|---|---|---|
| Unik `Nav-Call-Id` per kall (som i dag) | 5 | **5** |
| Identiske headere | 5 | **1** |

Dette kan også ses i backend-loggene i dev: én sidevisning gir i dag fire ulike `Nav-Call-Id`-verdier mot oversiktsendepunktet innenfor få millisekunder.

- `pnpm check` ✅
- `tsc --noEmit` ✅ (etter `next typegen`)
- `pnpm test`: 172/172 ✅

## Kontekst

Oppdaget under review av #979, som legger til et femte kallsted. Med denne fiksen inne blir det ekstra kallet der gratis, og #979 kan forenkles (kan f.eks. hente flagget direkte i server-komponentene bak Suspense i stedet for prop-trådning).